### PR TITLE
Fix build_tag.yml Github Workflow

### DIFF
--- a/.github/workflows/build_tag.yml
+++ b/.github/workflows/build_tag.yml
@@ -25,13 +25,18 @@ jobs:
     - name: Check-out code
       uses: actions/checkout@v3
     - name: Build container images
+      env:
+        # VERSION must be set for docker image to be tagged correctly
+        VERSION: ${{ needs.get-version.outputs.version }}
       run: make
-    - name: Push container images if needed
-      if: ${{ github.repository == 'antrea-io/antrea-ui' && github.event_name == 'push' && github.ref == 'refs/heads/main' }}
+    - name: Push container images
+      # in case workflow runs from a fork
+      if: ${{ github.repository == 'antrea-io/antrea-ui' }}
       env:
         DOCKER_USERNAME: ${{ secrets.DOCKER_USERNAME }}
         DOCKER_PASSWORD: ${{ secrets.DOCKER_PASSWORD }}
         VERSION: ${{ needs.get-version.outputs.version }}
       run: |
+        echo "$DOCKER_PASSWORD" | docker login -u "$DOCKER_USERNAME" --password-stdin
         docker push antrea/antrea-ui-frontend:"${VERSION}"
         docker push antrea/antrea-ui-backend:"${VERSION}"

--- a/.github/workflows/process_release.yml
+++ b/.github/workflows/process_release.yml
@@ -37,7 +37,7 @@ jobs:
         TAG: ${{ github.ref }}
       run: |
         version=${TAG:10}
-        echo "::set-output name=version::$version"
+        echo "version=$version" >> $GITHUB_OUTPUT
     - name: Update Helm index with Antrea UI archive
       uses: benc-uk/workflow-dispatch@v121
       with:


### PR DESCRIPTION
The step for pushing built images was wrong: because of an invalid "if" condition, the step was skipped and no container image was pushed for tags.

We also remove a deprecated set_output command from the process_release.yml Workflow.