### PR TITLE
Configure rate-limiting (for logins and traceflows) in main

### DIFF
--- a/cmd/server/main.go
+++ b/cmd/server/main.go
@@ -130,6 +130,8 @@ func run() error {
 		passwordStore,
 		tokenManager,
 		server.SetCookieSecure(cookieSecure),
+		server.SetMaxLoginsPerSecond(maxLoginsPerSecond),
+		server.SetMaxTraceflowsPerHour(maxTraceflowsPerHour),
 	)
 
 	var router *gin.Engine


### PR DESCRIPTION
The server was not configured as expected, the code must have been lost during a rebase.