### PR TITLE
Fix frontend crash in Summary page when data is missing

### DIFF
--- a/client/web/antrea-ui/src/api/info.tsx
+++ b/client/web/antrea-ui/src/api/info.tsx
@@ -38,23 +38,22 @@ export interface Condition {
 
 export interface ControllerCondition extends Condition { }
 
-// The fields which we do not need at the moment are made optional
 export interface ControllerInfo {
     metadata: {
         name: string
     }
-    version: string
-    podRef: K8sRef
-    nodeRef: K8sRef
+    version?: string
+    podRef?: K8sRef
+    nodeRef?: K8sRef
     serviceRef?: K8sRef
     networkPolicyControllerInfo?: NetworkPolicyControllerInfo
-    connectedAgentNum: number
-    controllerConditions: ControllerCondition[]
+    connectedAgentNum?: number
+    controllerConditions?: ControllerCondition[]
     apiPort?: number
 }
 
 interface OVSInfo {
-    version: string
+    version?: string
     bridgeName?: string
     flowTable?: Map<string,number>
 }
@@ -65,14 +64,14 @@ export interface AgentInfo {
     metadata: {
         name: string
     }
-    version: string
-    podRef: K8sRef
-    nodeRef: K8sRef
-    nodeSubnets: string[]
-    ovsInfo: OVSInfo
+    version?: string
+    podRef?: K8sRef
+    nodeRef?: K8sRef
+    nodeSubnets?: string[]
+    ovsInfo?: OVSInfo
     networkPolicyControllerInfo?: NetworkPolicyControllerInfo
-    localPodNum: number
-    agentConditions: AgentCondition[]
+    localPodNum?: number
+    agentConditions?: AgentCondition[]
     apiPort?: number
 }
 

--- a/client/web/antrea-ui/src/routes/summary.tsx
+++ b/client/web/antrea-ui/src/routes/summary.tsx
@@ -23,18 +23,20 @@ import { WaitForAPIResource } from '../components/progress';
 
 type Property = string
 
-const controllerProperties: Property[] = ["Name", "Version", "Pod Name", "Node Name", "Connected Agents", "Healthy", "Last Heartbeat"];
-const agentProperties: Property[] = ["Name", "Version", "Pod Name", "Node Name", "Local Pods", "Node Subnets", "OVS Version", "Healthy", "Last Heartbeat"];
+const controllerProperties: Property[] = ['Name', 'Version', 'Pod Name', 'Node Name', 'Connected Agents', 'Healthy', 'Last Heartbeat'];
+const agentProperties: Property[] = ['Name', 'Version', 'Pod Name', 'Node Name', 'Local Pods', 'Node Subnets', 'OVS Version', 'Healthy', 'Last Heartbeat'];
 
-function refToString(ref: K8sRef): string {
+function refToString(ref: K8sRef | undefined): string {
+    if (!ref) return 'Unknown';
     if (ref.namespace) return ref.namespace + '/' + ref.name;
     return ref.name;
 }
 
 // returns status and last heartbeat time
-function getConditionInfo(conditions: Condition[], name: string): [string, string] {
+function getConditionInfo(conditions: Condition[] | undefined, name: string): [string, string] {
+    if (!conditions) return ['False', 'None'];
     const condition = conditions.find(c => c.type === name);
-    if (!condition) return ["False", "None"];
+    if (!condition) return ['False', 'None'];
     return [condition.status, new Date(condition.lastHeartbeatTime).toLocaleString()];
 }
 
@@ -42,7 +44,7 @@ function controllerPropertyValues(controller: ControllerInfo): string[] {
     const [healthy, lastHeartbeat] = getConditionInfo(controller.controllerConditions, 'ControllerHealthy');
     return [
         controller.metadata.name,
-        controller.version,
+        controller?.version ?? 'Unknown',
         refToString(controller.podRef),
         refToString(controller.nodeRef),
         (controller.connectedAgentNum??0).toString(),
@@ -55,12 +57,12 @@ function agentPropertyValues(agent: AgentInfo): string[] {
     const [healthy, lastHeartbeat] = getConditionInfo(agent.agentConditions, 'AgentHealthy');
     return [
         agent.metadata.name,
-        agent.version,
+        agent?.version ?? 'Unknown',
         refToString(agent.podRef),
         refToString(agent.nodeRef),
         (agent.localPodNum??0).toString(),
-        agent.nodeSubnets.join(','),
-        agent.ovsInfo.version,
+        agent.nodeSubnets?.join(',') ?? 'None',
+        agent?.ovsInfo?.version ?? 'Unknown',
         healthy,
         lastHeartbeat,
     ];


### PR DESCRIPTION
When Antrea runs in networkPolicyOnly mode, the nodeSubnets field is missing (omitted because empty) from AntreaAgentInfo resources. The frontend needs to handle this case gracefully.

Fixes #22