### PR TITLE
Improve /auth API endpoints

### DIFF
--- a/client/web/antrea-ui/src/api/auth.tsx
+++ b/client/web/antrea-ui/src/api/auth.tsx
@@ -36,7 +36,7 @@ api.defaults.withCredentials = true;
 
 export const authAPI = {
     login: async (username: string, password: string): Promise<Token> => {
-        return api.get(`auth/login`, {
+        return api.post(`auth/login`, {}, {
             headers: {
                 "Authorization": "Basic " + encode(username + ":" + password),
             },
@@ -44,7 +44,7 @@ export const authAPI = {
     },
 
     logout: async (): Promise<void> => {
-        return api.get(`auth/logout`).then(_ => {}).catch((error) => handleError(error, "Error when trying to log out"));
+        return api.post(`auth/logout`, {}).then(_ => {}).catch((error) => handleError(error, "Error when trying to log out"));
     },
 
     refreshToken: async (): Promise<void> => {

--- a/pkg/server/server_test.go
+++ b/pkg/server/server_test.go
@@ -120,9 +120,9 @@ func (ts *testServer) authorizeRequest(req *http.Request) {
 func TestAuthorization(t *testing.T) {
 	unprotectedRoutes := map[string]bool{
 		"GET /healthz":                   true,
-		"GET /api/v1/auth/login":         true,
+		"POST /api/v1/auth/login":        true,
 		"GET /api/v1/auth/refresh_token": true,
-		"GET /api/v1/auth/logout":        true,
+		"POST /api/v1/auth/logout":       true,
 		"GET /api/v1/version":            true,
 	}
 	ts := newTestServer(t)

--- a/test/e2e/api_test.go
+++ b/test/e2e/api_test.go
@@ -38,7 +38,7 @@ const (
 func TestLoginRateLimiting(t *testing.T) {
 	ctx := context.Background()
 	badLogin := func() int {
-		resp, err := Request(ctx, host, "GET", "api/v1/auth/login", nil, func(req *http.Request) {
+		resp, err := Request(ctx, host, "POST", "api/v1/auth/login", nil, func(req *http.Request) {
 			req.SetBasicAuth("admin", "bad") // invalid password
 		})
 		require.NoError(t, err)

--- a/test/e2e/client.go
+++ b/test/e2e/client.go
@@ -32,7 +32,7 @@ type AuthProvider struct {
 
 func (p *AuthProvider) getAccessToken(ctx context.Context, host string) (string, error) {
 	login := func(ctx context.Context) (*http.Response, error) {
-		return Request(ctx, host, "GET", "api/v1/auth/login", nil, func(req *http.Request) {
+		return Request(ctx, host, "POST", "api/v1/auth/login", nil, func(req *http.Request) {
 			req.SetBasicAuth("admin", "admin") // default credentials
 		})
 	}


### PR DESCRIPTION
* Use POST instead of GET for /login and /logout. This seems to be better practice, but it probably doesn't make a big difference with our current design.
* Support refresh token passed in Authorization header for /refresh_token endpoint. This is mostly for the benefit of non-browser clients.
* Use a session cookie to store the refresh token instead of a fixed lifetime based on token expiry.