### PR TITLE
Move API server handlers to their own packages.

### DIFF
--- a/cmd/server/main.go
+++ b/cmd/server/main.go
@@ -132,9 +132,7 @@ func run() error {
 		k8sProxyHandler,
 		passwordStore,
 		tokenManager,
-		server.SetCookieSecure(config.Auth.CookieSecure),
-		server.SetMaxLoginsPerSecond(config.Limits.MaxLoginsPerSecond),
-		server.SetMaxTraceflowsPerHour(config.Limits.MaxTraceflowsPerHour),
+		config,
 	)
 
 	var router *gin.Engine

--- a/pkg/server/api/account_test.go
+++ b/pkg/server/api/account_test.go
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-package server
+package api
 
 import (
 	"bytes"

--- a/pkg/server/api/auth_test.go
+++ b/pkg/server/api/auth_test.go
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-package server
+package api
 
 import (
 	"encoding/json"
@@ -102,7 +102,7 @@ func TestLogin(t *testing.T) {
 	})
 
 	t.Run("rate limiting 0/s", func(t *testing.T) {
-		ts := newTestServer(t, SetMaxLoginsPerSecond(0))
+		ts := newTestServer(t, setMaxLoginsPerSecond(0))
 		rr := sendRequest(ts, func(req *http.Request) {
 			req.SetBasicAuth(username, password)
 		})
@@ -110,7 +110,7 @@ func TestLogin(t *testing.T) {
 	})
 
 	t.Run("rate limiting 5/s", func(t *testing.T) {
-		ts := newTestServer(t, SetMaxLoginsPerSecond(5))
+		ts := newTestServer(t, setMaxLoginsPerSecond(5))
 		ts.passwordStore.EXPECT().Compare(gomock.Any(), []byte(wrongPassword)).Return(fmt.Errorf("bad password")).AnyTimes()
 		rr := sendRequest(ts, func(req *http.Request) {
 			req.SetBasicAuth(username, wrongPassword)

--- a/pkg/server/api/info.go
+++ b/pkg/server/api/info.go
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-package server
+package api
 
 import (
 	"fmt"
@@ -23,6 +23,8 @@ import (
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime/schema"
+
+	"antrea.io/antrea-ui/pkg/server/errors"
 )
 
 var (
@@ -38,69 +40,69 @@ var (
 	}
 )
 
-func (s *server) GetControllerInfo(c *gin.Context) {
-	if sError := func() *serverError {
+func (s *Server) GetControllerInfo(c *gin.Context) {
+	if sError := func() *errors.ServerError {
 		controllerInfo, err := s.k8sClient.Resource(controllerInfoGVR).Get(c, "antrea-controller", metav1.GetOptions{})
 		if apierrors.IsNotFound(err) {
-			return &serverError{
-				code:    http.StatusNotFound,
-				message: "Controller Info not found",
+			return &errors.ServerError{
+				Code:    http.StatusNotFound,
+				Message: "Controller Info not found",
 			}
 		} else if err != nil {
-			return &serverError{
-				code: http.StatusInternalServerError,
-				err:  fmt.Errorf("error when getting Controller Info CR: %w", err),
+			return &errors.ServerError{
+				Code: http.StatusInternalServerError,
+				Err:  fmt.Errorf("error when getting Controller Info CR: %w", err),
 			}
 		}
 		c.JSON(http.StatusOK, controllerInfo)
 		return nil
 	}(); sError != nil {
-		s.HandleError(c, sError)
+		errors.HandleError(c, sError)
 		s.LogError(sError, "Failed to get controller info")
 	}
 }
 
-func (s *server) GetAgentInfos(c *gin.Context) {
-	if sError := func() *serverError {
+func (s *Server) GetAgentInfos(c *gin.Context) {
+	if sError := func() *errors.ServerError {
 		agentInfos, err := s.k8sClient.Resource(agentInfoGVR).List(c, metav1.ListOptions{})
 		if err != nil {
-			return &serverError{
-				code: http.StatusInternalServerError,
-				err:  fmt.Errorf("error when listing Agent Info CRs: %w", err),
+			return &errors.ServerError{
+				Code: http.StatusInternalServerError,
+				Err:  fmt.Errorf("error when listing Agent Info CRs: %w", err),
 			}
 		}
 		c.JSON(http.StatusOK, agentInfos.Items)
 		return nil
 	}(); sError != nil {
-		s.HandleError(c, sError)
+		errors.HandleError(c, sError)
 		s.LogError(sError, "Failed to list agent infos")
 	}
 }
 
-func (s *server) GetAgentInfo(c *gin.Context) {
+func (s *Server) GetAgentInfo(c *gin.Context) {
 	name := c.Param("name")
-	if sError := func() *serverError {
+	if sError := func() *errors.ServerError {
 		agentInfo, err := s.k8sClient.Resource(agentInfoGVR).Get(c, name, metav1.GetOptions{})
 		if apierrors.IsNotFound(err) {
-			return &serverError{
-				code:    http.StatusNotFound,
-				message: "Agent Info not found",
+			return &errors.ServerError{
+				Code:    http.StatusNotFound,
+				Message: "Agent Info not found",
 			}
 		} else if err != nil {
-			return &serverError{
-				code: http.StatusInternalServerError,
-				err:  fmt.Errorf("error when getting Agent Info CR: %w", err),
+			return &errors.ServerError{
+				Code: http.StatusInternalServerError,
+				Err:  fmt.Errorf("error when getting Agent Info CR: %w", err),
 			}
 		}
 		c.JSON(http.StatusOK, agentInfo)
 		return nil
 	}(); sError != nil {
-		s.HandleError(c, sError)
+		errors.HandleError(c, sError)
 		s.LogError(sError, "Failed to get agent info", "name", name)
 	}
 }
 
-func (s *server) AddInfoRoutes(r *gin.RouterGroup) {
+func (s *Server) AddInfoRoutes(r *gin.RouterGroup) {
 	r = r.Group("/info")
 	removalDate := time.Date(2023, 7, 1, 0, 0, 0, 0, time.UTC)
 	r.Use(s.checkBearerToken, announceDeprecationMiddleware(removalDate, "use /k8s instead"))

--- a/pkg/server/api/info_test.go
+++ b/pkg/server/api/info_test.go
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-package server
+package api
 
 import (
 	"context"

--- a/pkg/server/api/k8s_test.go
+++ b/pkg/server/api/k8s_test.go
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-package server
+package api
 
 import (
 	"io"

--- a/pkg/server/api/server.go
+++ b/pkg/server/api/server.go
@@ -1,0 +1,130 @@
+// Copyright 2023 Antrea Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package api
+
+import (
+	"fmt"
+	"net/http"
+	"strings"
+	"time"
+
+	"github.com/gin-gonic/gin"
+	"github.com/go-logr/logr"
+	"k8s.io/client-go/dynamic"
+
+	"antrea.io/antrea-ui/pkg/auth"
+	serverconfig "antrea.io/antrea-ui/pkg/config/server"
+	"antrea.io/antrea-ui/pkg/handlers/traceflow"
+	"antrea.io/antrea-ui/pkg/password"
+	"antrea.io/antrea-ui/pkg/server/errors"
+	"antrea.io/antrea-ui/pkg/version"
+)
+
+type serverConfig struct {
+	// keep all fields exported, so the config struct can be logged
+	CookieSecure         bool
+	MaxTraceflowsPerHour int
+	MaxLoginsPerSecond   int
+}
+
+type Server struct {
+	logger                   logr.Logger
+	k8sClient                dynamic.Interface
+	traceflowRequestsHandler traceflow.RequestsHandler
+	k8sProxyHandler          http.Handler
+	passwordStore            password.Store
+	tokenManager             auth.TokenManager
+	config                   serverConfig
+}
+
+func NewServer(
+	logger logr.Logger,
+	k8sClient dynamic.Interface,
+	traceflowRequestsHandler traceflow.RequestsHandler,
+	k8sProxyHandler http.Handler,
+	passwordStore password.Store,
+	tokenManager auth.TokenManager,
+	config *serverconfig.Config,
+) *Server {
+	c := serverConfig{
+		CookieSecure:         config.Auth.CookieSecure,
+		MaxTraceflowsPerHour: config.Limits.MaxTraceflowsPerHour,
+		MaxLoginsPerSecond:   config.Limits.MaxLoginsPerSecond,
+	}
+	logger.Info("Created API server config", "config", c)
+	return &Server{
+		logger:                   logger,
+		k8sClient:                k8sClient,
+		traceflowRequestsHandler: traceflowRequestsHandler,
+		k8sProxyHandler:          k8sProxyHandler,
+		passwordStore:            passwordStore,
+		tokenManager:             tokenManager,
+		config:                   c,
+	}
+}
+
+func (s *Server) checkBearerToken(c *gin.Context) {
+	if sError := func() *errors.ServerError {
+		auth := c.GetHeader("Authorization")
+		if auth == "" {
+			return &errors.ServerError{
+				Code:    http.StatusUnauthorized,
+				Message: "Missing Authorization header",
+			}
+		}
+		t := strings.Split(auth, " ")
+		if len(t) != 2 || t[0] != "Bearer" {
+			return &errors.ServerError{
+				Code:    http.StatusUnauthorized,
+				Message: "Authorization header does not have valid format",
+			}
+		}
+		if err := s.tokenManager.VerifyToken(t[1]); err != nil {
+			return &errors.ServerError{
+				Code:    http.StatusUnauthorized,
+				Message: "Invalid Bearer token",
+				Err:     err,
+			}
+		}
+		return nil
+	}(); sError != nil {
+		errors.HandleError(c, sError)
+		c.Abort()
+		return
+	}
+}
+
+func announceDeprecationMiddleware(removalDate time.Time, message string) gin.HandlerFunc {
+	return func(c *gin.Context) {
+		c.Header("Warning", fmt.Sprintf(`299 - "Deprecated API: %s"`, message))
+		c.Header("Sunset", removalDate.UTC().Format(http.TimeFormat))
+	}
+}
+
+func (s *Server) AddRoutes(r *gin.RouterGroup) {
+	apiv1 := r.Group("/api/v1")
+	apiv1.GET("/version", func(c *gin.Context) {
+		c.String(http.StatusOK, version.GetFullVersionWithRuntimeInfo())
+	})
+	s.AddTraceflowRoutes(apiv1)
+	s.AddInfoRoutes(apiv1)
+	s.AddAccountRoutes(apiv1)
+	s.AddAuthRoutes(apiv1)
+	s.AddK8sRoutes(apiv1)
+}
+
+func (s *Server) LogError(sError *errors.ServerError, msg string, keysAndValues ...interface{}) {
+	errors.LogError(s.logger, sError, msg, keysAndValues...)
+}

--- a/pkg/server/api/traceflow_test.go
+++ b/pkg/server/api/traceflow_test.go
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-package server
+package api
 
 import (
 	"bytes"
@@ -147,13 +147,13 @@ func TestTraceflowRequestRateLimiting(t *testing.T) {
 	}
 
 	t.Run("0/s", func(t *testing.T) {
-		ts := newTestServer(t, SetMaxTraceflowsPerHour(0))
+		ts := newTestServer(t, setMaxTraceflowsPerHour(0))
 		rr := sendRequest(ts)
 		assert.Equal(t, http.StatusTooManyRequests, rr.Code)
 	})
 
 	t.Run("5/s", func(t *testing.T) {
-		ts := newTestServer(t, SetMaxTraceflowsPerHour(5*3600))
+		ts := newTestServer(t, setMaxTraceflowsPerHour(5*3600))
 		ts.traceflowRequestsHandler.EXPECT().CreateRequest(gomock.Any(), &traceflowhandler.Request{
 			Object: tf,
 		}).Return(uuid.NewString(), nil).AnyTimes()

--- a/pkg/server/errors/error.go
+++ b/pkg/server/errors/error.go
@@ -12,37 +12,38 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-package server
+package errors
 
 import (
 	"net/http"
 
 	"github.com/gin-gonic/gin"
+	"github.com/go-logr/logr"
 )
 
-type serverError struct {
-	code    int
-	err     error
-	message string
+type ServerError struct {
+	Code    int
+	Err     error
+	Message string
 }
 
-func (s *server) HandleError(c *gin.Context, sError *serverError) {
+func HandleError(c *gin.Context, sError *ServerError) {
 	if sError == nil {
-		panic("serverError is nil")
+		panic("ServerError is nil")
 	}
-	if sError.err != nil {
-		c.Error(sError.err)
+	if sError.Err != nil {
+		c.Error(sError.Err)
 	}
-	if sError.code == http.StatusInternalServerError {
-		c.JSON(sError.code, "Internal Server Error")
+	if sError.Code == http.StatusInternalServerError {
+		c.JSON(sError.Code, "Internal Server Error")
 	} else {
-		c.JSON(sError.code, sError.message)
+		c.JSON(sError.Code, sError.Message)
 	}
 }
 
-func (s *server) LogError(sError *serverError, msg string, keysAndValues ...interface{}) {
-	if sError == nil || sError.err == nil {
+func LogError(logger logr.Logger, sError *ServerError, msg string, keysAndValues ...interface{}) {
+	if sError == nil || sError.Err == nil {
 		return
 	}
-	s.logger.Error(sError.err, msg, keysAndValues...)
+	logger.Error(sError.Err, msg, keysAndValues...)
 }


### PR DESCRIPTION
This is a code cleanup, before new routes are added (for OIDC support) which are not going to be part of the API itself.