### PR TITLE
Move auth routes out of API

### DIFF
--- a/build/charts/antrea-ui/templates/_nginx_conf.tpl
+++ b/build/charts/antrea-ui/templates/_nginx_conf.tpl
@@ -41,6 +41,21 @@ server {
             {{- end }}
         }
 
+        # at the moment, the config is the same as for /api
+        location /auth {
+            proxy_http_version 1.1;
+            proxy_pass_request_headers on;
+            proxy_hide_header Access-Control-Allow-Origin;
+            proxy_pass http://127.0.0.1:{{ .Values.backend.port }};
+            # ensure the correct flags are set, even though the api server should already be setting them
+            {{- $secure := include "cookieSecure" . -}}
+            {{- if eq $secure "true" }}
+            proxy_cookie_flags ~ httponly secure samesite=strict;
+            {{- else }}
+            proxy_cookie_flags ~ httponly samesite=strict;
+            {{- end }}
+        }
+
         location / {
             try_files $uri $uri/ /index.html;
         }

--- a/client/web/antrea-ui/src/api/auth.tsx
+++ b/client/web/antrea-ui/src/api/auth.tsx
@@ -20,7 +20,7 @@ import { encode } from 'base-64';
 import { setToken } from './token';
 import config from '../config';
 
-const { apiUri } = config;
+const { apiServer } = config;
 
 interface Token {
     tokenType: string
@@ -29,7 +29,7 @@ interface Token {
 }
 
 const api = axios.create({
-    baseURL: apiUri,
+    baseURL: apiServer,
 });
 
 api.defaults.withCredentials = true;

--- a/client/web/antrea-ui/src/api/axios.test.tsx
+++ b/client/web/antrea-ui/src/api/axios.test.tsx
@@ -54,7 +54,7 @@ describe('axios instance', () => {
     test('expired token', async () => {
         const scope = nock('http://localhost')
             .get('/api/v1/test').matchHeader('Authorization', `Bearer ${token1}`).reply(401, 'expired token')
-            .get('/api/v1/auth/refresh_token').reply(200, JSON.stringify({
+            .get('/auth/refresh_token').reply(200, JSON.stringify({
                 accessToken: token2,
                 tokenType: 'Bearer',
                 expiresIn: 3600,
@@ -78,7 +78,7 @@ describe('axios instance', () => {
     test('failed refresh', async () => {
         const scope = nock('http://localhost')
             .get('/api/v1/test').matchHeader('Authorization', `Bearer ${token1}`).reply(401, 'expired token')
-            .get('/api/v1/auth/refresh_token').reply(500, 'unknown error');
+            .get('/auth/refresh_token').reply(500, 'unknown error');
 
         getTokenMock.mockReturnValueOnce(token1);
 
@@ -93,7 +93,7 @@ describe('axios instance', () => {
     test('failed refresh with unauthenticated', async () => {
         const scope = nock('http://localhost')
             .get('/api/v1/test').matchHeader('Authorization', `Bearer ${token1}`).reply(401, 'expired token')
-            .get('/api/v1/auth/refresh_token').reply(401, 'expired cookie');
+            .get('/auth/refresh_token').reply(401, 'expired cookie');
 
         getTokenMock.mockReturnValueOnce(token1);
 

--- a/pkg/server/api/server.go
+++ b/pkg/server/api/server.go
@@ -34,9 +34,7 @@ import (
 
 type serverConfig struct {
 	// keep all fields exported, so the config struct can be logged
-	CookieSecure         bool
 	MaxTraceflowsPerHour int
-	MaxLoginsPerSecond   int
 }
 
 type Server struct {
@@ -59,9 +57,7 @@ func NewServer(
 	config *serverconfig.Config,
 ) *Server {
 	c := serverConfig{
-		CookieSecure:         config.Auth.CookieSecure,
 		MaxTraceflowsPerHour: config.Limits.MaxTraceflowsPerHour,
-		MaxLoginsPerSecond:   config.Limits.MaxLoginsPerSecond,
 	}
 	logger.Info("Created API server config", "config", c)
 	return &Server{
@@ -121,7 +117,6 @@ func (s *Server) AddRoutes(r *gin.RouterGroup) {
 	s.AddTraceflowRoutes(apiv1)
 	s.AddInfoRoutes(apiv1)
 	s.AddAccountRoutes(apiv1)
-	s.AddAuthRoutes(apiv1)
 	s.AddK8sRoutes(apiv1)
 }
 

--- a/pkg/server/auth_test.go
+++ b/pkg/server/auth_test.go
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-package api
+package server
 
 import (
 	"encoding/json"
@@ -45,7 +45,7 @@ func TestLogin(t *testing.T) {
 	wrongPassword := "abc"
 
 	sendRequest := func(ts *testServer, mutators ...func(req *http.Request)) *httptest.ResponseRecorder {
-		req := httptest.NewRequest("POST", "/api/v1/auth/login", nil)
+		req := httptest.NewRequest("POST", "/auth/login", nil)
 		for _, m := range mutators {
 			m(req)
 		}
@@ -79,7 +79,7 @@ func TestLogin(t *testing.T) {
 		cookie := getRefreshTokenSetCookie(rr.Result())
 		require.NotNil(t, cookie, "Missing refresh token cookie in response")
 		assert.Equal(t, refreshToken.Raw, cookie.Value)
-		assert.Equal(t, "/api/v1/auth", cookie.Path)
+		assert.Equal(t, "/auth", cookie.Path)
 		assert.Equal(t, "", cookie.Domain)
 		assert.Equal(t, 0, cookie.MaxAge)
 		assert.True(t, cookie.HttpOnly)
@@ -133,7 +133,7 @@ func TestLogin(t *testing.T) {
 
 func TestRefreshToken(t *testing.T) {
 	sendRequestWithAuthorizationHeader := func(ts *testServer, refreshToken string) *httptest.ResponseRecorder {
-		req := httptest.NewRequest("GET", "/api/v1/auth/refresh_token", nil)
+		req := httptest.NewRequest("GET", "/auth/refresh_token", nil)
 		req.Header.Add("Authorization", fmt.Sprintf("Bearer %s", refreshToken))
 		rr := httptest.NewRecorder()
 		ts.router.ServeHTTP(rr, req)
@@ -141,7 +141,7 @@ func TestRefreshToken(t *testing.T) {
 	}
 
 	sendRequestWithCookie := func(ts *testServer, refreshToken string) *httptest.ResponseRecorder {
-		req := httptest.NewRequest("GET", "/api/v1/auth/refresh_token", nil)
+		req := httptest.NewRequest("GET", "/auth/refresh_token", nil)
 		req.AddCookie(&http.Cookie{
 			Name:  "antrea-ui-refresh-token",
 			Value: refreshToken,
@@ -152,7 +152,7 @@ func TestRefreshToken(t *testing.T) {
 	}
 
 	sendRequestNoAuth := func(ts *testServer) *httptest.ResponseRecorder {
-		req := httptest.NewRequest("GET", "/api/v1/auth/refresh_token", nil)
+		req := httptest.NewRequest("GET", "/auth/refresh_token", nil)
 		rr := httptest.NewRecorder()
 		ts.router.ServeHTTP(rr, req)
 		return rr
@@ -213,7 +213,7 @@ func TestRefreshToken(t *testing.T) {
 
 func TestLogout(t *testing.T) {
 	sendRequest := func(ts *testServer, refreshToken *string) *httptest.ResponseRecorder {
-		req := httptest.NewRequest("POST", "/api/v1/auth/logout", nil)
+		req := httptest.NewRequest("POST", "/auth/logout", nil)
 		if refreshToken != nil {
 			req.AddCookie(&http.Cookie{
 				Name:  "antrea-ui-refresh-token",

--- a/pkg/server/server_test.go
+++ b/pkg/server/server_test.go
@@ -1,0 +1,86 @@
+// Copyright 2023 Antrea Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package server
+
+import (
+	"fmt"
+	"testing"
+	"time"
+
+	"github.com/gin-gonic/gin"
+	"github.com/go-logr/logr/testr"
+	"github.com/golang/mock/gomock"
+	"github.com/google/uuid"
+
+	"antrea.io/antrea-ui/pkg/auth"
+	authtesting "antrea.io/antrea-ui/pkg/auth/testing"
+	serverconfig "antrea.io/antrea-ui/pkg/config/server"
+	passwordtesting "antrea.io/antrea-ui/pkg/password/testing"
+)
+
+func init() {
+	// avoid verbose Gin logging
+	gin.SetMode(gin.ReleaseMode)
+}
+
+type testServer struct {
+	s             *Server
+	router        *gin.Engine
+	passwordStore *passwordtesting.MockStore
+	tokenManager  *authtesting.MockTokenManager
+}
+
+type testServerOptions func(c *serverconfig.Config)
+
+func setMaxLoginsPerSecond(v int) testServerOptions {
+	return func(c *serverconfig.Config) {
+		c.Limits.MaxLoginsPerSecond = v
+	}
+}
+
+func newTestServer(t *testing.T, options ...testServerOptions) *testServer {
+	logger := testr.New(t)
+	ctrl := gomock.NewController(t)
+	passwordStore := passwordtesting.NewMockStore(ctrl)
+	tokenManager := authtesting.NewMockTokenManager(ctrl)
+
+	config := &serverconfig.Config{}
+	// disable rate limiting by default
+	config.Limits.MaxLoginsPerSecond = -1
+	for _, fn := range options {
+		fn(config)
+	}
+
+	// we use nil for parameters which are only used by the API server
+	s := NewServer(logger, nil, nil, nil, passwordStore, tokenManager, config)
+	router := gin.Default()
+	s.AddRoutes(router)
+	return &testServer{
+		s:             s,
+		router:        router,
+		passwordStore: passwordStore,
+		tokenManager:  tokenManager,
+	}
+}
+
+const testTokenValidity = 1 * time.Hour
+
+func getTestToken() *auth.Token {
+	return &auth.Token{
+		Raw:       fmt.Sprintf("token-%s", uuid.NewString()),
+		ExpiresIn: testTokenValidity,
+		ExpiresAt: time.Now().Add(testTokenValidity),
+	}
+}

--- a/pkg/server/utils/cookie/cookie.go
+++ b/pkg/server/utils/cookie/cookie.go
@@ -1,0 +1,62 @@
+// Copyright 2023 Antrea Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package cookie
+
+import (
+	"net/http"
+)
+
+const (
+	// #nosec G101: not credentials
+	refreshTokenCookieName = "antrea-ui-refresh-token"
+	refreshTokenCookiePath = "/auth"
+)
+
+func SetRefreshTokenCookie(w http.ResponseWriter, token string, cookieSecure bool) {
+	http.SetCookie(w, &http.Cookie{
+		Name:     refreshTokenCookieName,
+		Value:    token,
+		Path:     refreshTokenCookiePath,
+		MaxAge:   0, // make it a session cookie
+		Secure:   cookieSecure,
+		HttpOnly: true,
+		SameSite: http.SameSiteStrictMode,
+	})
+}
+
+func UnsetRefreshTokenCookie(req *http.Request, w http.ResponseWriter) (string, bool) {
+	cookie, err := req.Cookie(refreshTokenCookieName)
+	if err != nil {
+		// no cookie
+		return "", false
+	}
+	token := cookie.Value
+	http.SetCookie(w, &http.Cookie{
+		Name:   refreshTokenCookieName,
+		Value:  "",
+		Path:   refreshTokenCookiePath,
+		MaxAge: -1,
+	})
+	return token, true
+}
+
+func GetRefreshTokenFromCookie(req *http.Request) (string, bool) {
+	cookie, err := req.Cookie(refreshTokenCookieName)
+	if err != nil {
+		// no cookie
+		return "", false
+	}
+	return cookie.Value, true
+}

--- a/test/e2e/api_test.go
+++ b/test/e2e/api_test.go
@@ -33,7 +33,7 @@ import (
 func TestLoginRateLimiting(t *testing.T) {
 	ctx := context.Background()
 	badLogin := func() int {
-		resp, err := Request(ctx, host, "POST", "api/v1/auth/login", nil, func(req *http.Request) {
+		resp, err := Request(ctx, host, "POST", "auth/login", nil, func(req *http.Request) {
 			req.SetBasicAuth("admin", "bad") // invalid password
 		})
 		require.NoError(t, err)

--- a/test/e2e/client.go
+++ b/test/e2e/client.go
@@ -32,13 +32,13 @@ type AuthProvider struct {
 
 func (p *AuthProvider) getAccessToken(ctx context.Context, host string) (string, error) {
 	login := func(ctx context.Context) (*http.Response, error) {
-		return Request(ctx, host, "POST", "api/v1/auth/login", nil, func(req *http.Request) {
+		return Request(ctx, host, "POST", "auth/login", nil, func(req *http.Request) {
 			req.SetBasicAuth("admin", "admin") // default credentials
 		})
 	}
 
 	refreshToken := func(ctx context.Context) (*http.Response, error) {
-		return Request(ctx, host, "GET", "api/v1/auth/refresh_token", nil, func(req *http.Request) {
+		return Request(ctx, host, "GET", "auth/refresh_token", nil, func(req *http.Request) {
 			req.AddCookie(p.refreshCookie)
 		})
 	}


### PR DESCRIPTION
I believe it makes more sense to decouple authentication from the rest of the API. The API only requires a JWT token, which in theory could be obtained through different means.
With this change, all the cookie manipulation logic is moved out of the API, which makes the API itself more "RESTful".