### PR TITLE
Rename package apis/v1alpha1 to apis/v1

### DIFF
--- a/apis/v1/auth.go
+++ b/apis/v1/auth.go
@@ -12,19 +12,10 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-package v1alpha1
+package v1
 
-type FrontendAuthSettings struct {
-	BasicEnabled     bool   `json:"basicEnabled"`
-	OIDCEnabled      bool   `json:"oidcEnabled"`
-	OIDCProviderName string `json:"oidcProviderName,omitempty"`
-}
-
-// FrontendSettings are global settings exposed to the frontend, which can be
-// used to render some pages appropriately. These settings are not user-specific
-// and not confidential (the API for these settings is not protected by any auth
-// mechanism).
-type FrontendSettings struct {
-	Version string               `json:"version"`
-	Auth    FrontendAuthSettings `json:"auth"`
+type Token struct {
+	TokenType   string `json:"tokenType"`
+	AccessToken string `json:"accessToken"`
+	ExpiresIn   int64  `json:"expiresIn"`
 }

--- a/apis/v1/frontend_settings.go
+++ b/apis/v1/frontend_settings.go
@@ -12,10 +12,19 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-package v1alpha1
+package v1
 
-type Token struct {
-	TokenType   string `json:"tokenType"`
-	AccessToken string `json:"accessToken"`
-	ExpiresIn   int64  `json:"expiresIn"`
+type FrontendAuthSettings struct {
+	BasicEnabled     bool   `json:"basicEnabled"`
+	OIDCEnabled      bool   `json:"oidcEnabled"`
+	OIDCProviderName string `json:"oidcProviderName,omitempty"`
+}
+
+// FrontendSettings are global settings exposed to the frontend, which can be
+// used to render some pages appropriately. These settings are not user-specific
+// and not confidential (the API for these settings is not protected by any auth
+// mechanism).
+type FrontendSettings struct {
+	Version string               `json:"version"`
+	Auth    FrontendAuthSettings `json:"auth"`
 }

--- a/apis/v1/password.go
+++ b/apis/v1/password.go
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-package v1alpha1
+package v1
 
 type UpdatePassword struct {
 	// base64-encoded passwords

--- a/pkg/server/api/account.go
+++ b/pkg/server/api/account.go
@@ -20,13 +20,13 @@ import (
 
 	"github.com/gin-gonic/gin"
 
-	apisv1alpha1 "antrea.io/antrea-ui/apis/v1alpha1"
+	apisv1 "antrea.io/antrea-ui/apis/v1"
 	"antrea.io/antrea-ui/pkg/server/errors"
 )
 
 func (s *Server) UpdatePassword(c *gin.Context) {
 	if sError := func() *errors.ServerError {
-		var updatePassword apisv1alpha1.UpdatePassword
+		var updatePassword apisv1.UpdatePassword
 		if err := c.BindJSON(&updatePassword); err != nil {
 			return &errors.ServerError{
 				Code:    http.StatusBadRequest,

--- a/pkg/server/api/account_test.go
+++ b/pkg/server/api/account_test.go
@@ -26,7 +26,7 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
-	apisv1alpha1 "antrea.io/antrea-ui/apis/v1alpha1"
+	apisv1 "antrea.io/antrea-ui/apis/v1"
 )
 
 func TestUpdatePassword(t *testing.T) {
@@ -50,7 +50,7 @@ func TestUpdatePassword(t *testing.T) {
 			ts.passwordStore.EXPECT().Compare(gomock.Any(), currentPassword),
 			ts.passwordStore.EXPECT().Update(gomock.Any(), newPassword),
 		)
-		rr := sendAuthorizedRequest(ts, &apisv1alpha1.UpdatePassword{
+		rr := sendAuthorizedRequest(ts, &apisv1.UpdatePassword{
 			CurrentPassword: currentPassword,
 			NewPassword:     newPassword,
 		})
@@ -60,7 +60,7 @@ func TestUpdatePassword(t *testing.T) {
 	t.Run("wrong password", func(t *testing.T) {
 		ts := newTestServer(t)
 		ts.passwordStore.EXPECT().Compare(gomock.Any(), wrongPassword).Return(fmt.Errorf("bad password"))
-		rr := sendAuthorizedRequest(ts, &apisv1alpha1.UpdatePassword{
+		rr := sendAuthorizedRequest(ts, &apisv1.UpdatePassword{
 			CurrentPassword: wrongPassword,
 			NewPassword:     newPassword,
 		})

--- a/pkg/server/api/frontend_settings.go
+++ b/pkg/server/api/frontend_settings.go
@@ -19,15 +19,15 @@ import (
 
 	"github.com/gin-gonic/gin"
 
-	apisv1alpha1 "antrea.io/antrea-ui/apis/v1alpha1"
+	apisv1 "antrea.io/antrea-ui/apis/v1"
 	serverconfig "antrea.io/antrea-ui/pkg/config/server"
 	"antrea.io/antrea-ui/pkg/version"
 )
 
-func buildFrontendSettingsFromConfig(config *serverconfig.Config) *apisv1alpha1.FrontendSettings {
-	return &apisv1alpha1.FrontendSettings{
+func buildFrontendSettingsFromConfig(config *serverconfig.Config) *apisv1.FrontendSettings {
+	return &apisv1.FrontendSettings{
 		Version: version.GetFullVersion(),
-		Auth: apisv1alpha1.FrontendAuthSettings{
+		Auth: apisv1.FrontendAuthSettings{
 			BasicEnabled:     config.Auth.Basic.Enabled,
 			OIDCEnabled:      config.Auth.OIDC.Enabled,
 			OIDCProviderName: config.Auth.OIDC.ProviderName,

--- a/pkg/server/api/server.go
+++ b/pkg/server/api/server.go
@@ -24,7 +24,7 @@ import (
 	"github.com/go-logr/logr"
 	"k8s.io/client-go/dynamic"
 
-	apisv1alpha1 "antrea.io/antrea-ui/apis/v1alpha1"
+	apisv1 "antrea.io/antrea-ui/apis/v1"
 	"antrea.io/antrea-ui/pkg/auth"
 	serverconfig "antrea.io/antrea-ui/pkg/config/server"
 	"antrea.io/antrea-ui/pkg/handlers/traceflow"
@@ -46,7 +46,7 @@ type Server struct {
 	passwordStore            password.Store
 	tokenManager             auth.TokenManager
 	config                   serverConfig
-	frontendSettings         *apisv1alpha1.FrontendSettings
+	frontendSettings         *apisv1.FrontendSettings
 }
 
 func NewServer(

--- a/pkg/server/auth.go
+++ b/pkg/server/auth.go
@@ -22,7 +22,7 @@ import (
 
 	"github.com/gin-gonic/gin"
 
-	apisv1alpha1 "antrea.io/antrea-ui/apis/v1alpha1"
+	apisv1 "antrea.io/antrea-ui/apis/v1"
 	"antrea.io/antrea-ui/pkg/server/errors"
 	"antrea.io/antrea-ui/pkg/server/ratelimit"
 	cookieutils "antrea.io/antrea-ui/pkg/server/utils/cookie"
@@ -66,7 +66,7 @@ func (s *Server) Login(c *gin.Context) {
 				Err:  fmt.Errorf("error when getting JWT token: %w", err),
 			}
 		}
-		resp := apisv1alpha1.Token{
+		resp := apisv1.Token{
 			AccessToken: token.Raw,
 			TokenType:   "Bearer",
 			ExpiresIn:   int64(token.ExpiresIn / time.Second),
@@ -116,7 +116,7 @@ func (s *Server) RefreshToken(c *gin.Context) {
 				Err:  fmt.Errorf("error when getting JWT token: %w", err),
 			}
 		}
-		resp := apisv1alpha1.Token{
+		resp := apisv1.Token{
 			AccessToken: token.Raw,
 			TokenType:   "Bearer",
 			ExpiresIn:   int64(token.ExpiresIn / time.Second),

--- a/pkg/server/auth_test.go
+++ b/pkg/server/auth_test.go
@@ -26,7 +26,7 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
-	apisv1alpha1 "antrea.io/antrea-ui/apis/v1alpha1"
+	apisv1 "antrea.io/antrea-ui/apis/v1"
 )
 
 func getRefreshTokenCookie(response *http.Response) *http.Cookie {
@@ -69,7 +69,7 @@ func TestLogin(t *testing.T) {
 		assert.Equal(t, http.StatusOK, rr.Code)
 
 		// check body of response
-		var data apisv1alpha1.Token
+		var data apisv1.Token
 		require.NoError(t, json.Unmarshal(rr.Body.Bytes(), &data))
 		assert.Equal(t, token.Raw, data.AccessToken)
 		assert.Equal(t, "Bearer", data.TokenType)
@@ -200,7 +200,7 @@ func TestRefreshToken(t *testing.T) {
 				assert.Equal(t, http.StatusOK, rr.Code)
 
 				// check body of response
-				var data apisv1alpha1.Token
+				var data apisv1.Token
 				require.NoError(t, json.Unmarshal(rr.Body.Bytes(), &data))
 				assert.Equal(t, token.Raw, data.AccessToken)
 				assert.Equal(t, "Bearer", data.TokenType)

--- a/test/e2e/client.go
+++ b/test/e2e/client.go
@@ -23,11 +23,11 @@ import (
 	"net/url"
 	"time"
 
-	apisv1alpha1 "antrea.io/antrea-ui/apis/v1alpha1"
+	apisv1 "antrea.io/antrea-ui/apis/v1"
 )
 
 func parseAccessToken(body []byte) (string, error) {
-	var data apisv1alpha1.Token
+	var data apisv1.Token
 	if err := json.Unmarshal(body, &data); err != nil {
 		return "", fmt.Errorf("invalid response body format: %w", err)
 	}
@@ -162,7 +162,7 @@ func GetAccessToken(ctx context.Context, host string) (string, error) {
 	return authProvider.getAccessToken(ctx, host)
 }
 
-func GetFrontendSettings(ctx context.Context) (*apisv1alpha1.FrontendSettings, error) {
+func GetFrontendSettings(ctx context.Context) (*apisv1.FrontendSettings, error) {
 	resp, err := Request(ctx, host, "GET", "api/v1/settings", nil)
 	if err != nil {
 		return nil, err
@@ -175,7 +175,7 @@ func GetFrontendSettings(ctx context.Context) (*apisv1alpha1.FrontendSettings, e
 	if err != nil {
 		return nil, err
 	}
-	var settings apisv1alpha1.FrontendSettings
+	var settings apisv1.FrontendSettings
 	if err := json.Unmarshal(body, &settings); err != nil {
 		return nil, err
 	}

--- a/test/e2e/data.go
+++ b/test/e2e/data.go
@@ -18,7 +18,7 @@ import (
 	"k8s.io/client-go/kubernetes"
 	"k8s.io/client-go/rest"
 
-	apisv1alpha1 "antrea.io/antrea-ui/apis/v1alpha1"
+	apisv1 "antrea.io/antrea-ui/apis/v1"
 )
 
 const (
@@ -33,5 +33,5 @@ var (
 	// the host address for accessing the Antrea UI
 	host string
 
-	settings *apisv1alpha1.FrontendSettings
+	settings *apisv1.FrontendSettings
 )


### PR DESCRIPTION
Since the API is already served under the "/api/v1" route, there is little reason to version the internal types as "v1alpha1". The versioning should probably be consistent.