### PR TITLE
Fix chart for older Helm versions

### DIFF
--- a/build/charts/antrea-ui/templates/_helpers.tpl
+++ b/build/charts/antrea-ui/templates/_helpers.tpl
@@ -27,9 +27,9 @@
 {{- end -}}
 
 {{- define "cookieSecure" -}}
-{{- if eq .Values.security.cookieSecure true }}
+{{- if eq (toString .Values.security.cookieSecure) "true" }}
 {{- true -}}
-{{- else if eq .Values.security.cookieSecure false }}
+{{- else if eq (toString .Values.security.cookieSecure) "false" }}
 {{- false -}}
 {{- else }}
 {{- .Values.https.enable -}}


### PR DESCRIPTION
When using Helm v3.6, installing the chart fails with: `error calling eq: incompatible types for comparison`.

This is because in older versions of Helm (built with older versions of Go), the `eq` built-in function does not support comparing a `nil` value to a non-`nil` value.

We can workaround this issue by converting the boolean value to a string with `toString`.

Fixes #42