### PR TITLE
Avoid transient failures in e2e_helm tests

### DIFF
--- a/test/e2e_helm/install_test.go
+++ b/test/e2e_helm/install_test.go
@@ -103,6 +103,9 @@ func TestInstall(t *testing.T) {
 			helm.Install(t, helmOptions, helmChartPath, releaseName)
 			defer helm.Delete(t, helmOptions, releaseName, true)
 
+			// workaround for https://github.com/gruntwork-io/terratest/issues/1329
+			time.Sleep(1 * time.Second)
+
 			// retry at most 60 times, with a 1s delay
 			// this is actually a no-op except for LoadBalancer Services
 			k8s.WaitUntilServiceAvailable(t, kubectlOptions, antreaUIServiceName, 60, 1*time.Second)


### PR DESCRIPTION
WaitUntilDeploymentAvailable can sometimes panic if called too quickly after creating the Deployment. We add a short sleep to avoid the issue.

See https://github.com/gruntwork-io/terratest/issues/1329