### PR TITLE
[Dependabot] Group golang.org/x updates

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -11,6 +11,9 @@ updates:
         - "k8s.io/*"
         update-types:
         - "patch"
+      golang.org/x:
+        patterns:
+        - "golang.org/x/*"
     ignore:
     - dependency-name: "k8s.io/*"
       update-types: ["version-update:semver-major", "version-update:semver-minor"] # ignore all except for patch updates


### PR DESCRIPTION
Instead of having 3+ Dependabot PRs every time there is a new patch release for golang.org/x packages, there will be a single PR to update all of them at the same time.