### PR TITLE
Bump jsdom-testing-mocks from 1.9.0 to 1.11.0 in /client/web/antrea-ui

### DIFF
--- a/client/web/antrea-ui/package.json
+++ b/client/web/antrea-ui/package.json
@@ -26,7 +26,7 @@
     "echarts": "^5.4.1",
     "echarts-for-react": "^3.0.1",
     "is-ip": "^5.0.1",
-    "jsdom-testing-mocks": "^1.9.0",
+    "jsdom-testing-mocks": "^1.11.0",
     "react": "^18.2.0",
     "react-dom": "^18.2.0",
     "react-hook-form": "^7.45.4",

--- a/client/web/antrea-ui/src/setupTests.ts
+++ b/client/web/antrea-ui/src/setupTests.ts
@@ -20,10 +20,12 @@ import axios from 'axios';
 // expect(element).toHaveTextContent(/react/i)
 // learn more: https://github.com/testing-library/jest-dom
 import '@testing-library/jest-dom/vitest';
-import { mockIntersectionObserver } from 'jsdom-testing-mocks';
+import { mockIntersectionObserver,  mockResizeObserver } from 'jsdom-testing-mocks';
 
 // required by Clarity
 mockIntersectionObserver();
+
+mockResizeObserver()
 
 // see https://github.com/nock/nock#axios
 axios.defaults.adapter = 'http';

--- a/client/web/antrea-ui/yarn.lock
+++ b/client/web/antrea-ui/yarn.lock
@@ -2790,10 +2790,10 @@ js-yaml@^4.1.0:
   dependencies:
     argparse "^2.0.1"
 
-jsdom-testing-mocks@^1.9.0:
-  version "1.9.0"
-  resolved "https://registry.yarnpkg.com/jsdom-testing-mocks/-/jsdom-testing-mocks-1.9.0.tgz#81ca7f5630cafe5d2084a02afaad8013f0df72db"
-  integrity sha512-NsuAqHFi0j4FcxIzSp8NOBNB+ln2T5PvJ0ShFgEXwMnTP2K68dRv5mJE/yJadbMAhzYqUL85Aj+cjhG9lHGapQ==
+jsdom-testing-mocks@^1.11.0:
+  version "1.11.0"
+  resolved "https://registry.yarnpkg.com/jsdom-testing-mocks/-/jsdom-testing-mocks-1.11.0.tgz#042f24f0e62463633a6f889f36a6e42678d49942"
+  integrity sha512-Od73jYGAl33C0aC7dRvhae2dlCEJ2cGa3j4797BHR/YoI1dJALxvEr2fZMfMZG4Tz/3c3C6xdwMnAXol5+HWZA==
   dependencies:
     bezier-easing "^2.1.0"
     css-mediaquery "^0.1.2"


### PR DESCRIPTION
This requires adding a missing call to mockResizeObserver() in setupTests.ts