### PR TITLE
Use v1beta1 API version for Traceflow

### DIFF
--- a/client/web/antrea-ui/src/api/traceflow.tsx
+++ b/client/web/antrea-ui/src/api/traceflow.tsx
@@ -30,13 +30,11 @@ export interface TraceflowPacket {
     dstIP?: string
     length?: number
     ipHeader?: {
-        srcIP?: string
         protocol?: number
         ttl?: number
         flags?: number
     }
     ipv6Header?: {
-        srcIP?: string
         nextHeader?: number
         hopLimit?: number
     }

--- a/pkg/handlers/traceflow/handler.go
+++ b/pkg/handlers/traceflow/handler.go
@@ -38,7 +38,7 @@ const (
 var (
 	traceflowGVR = schema.GroupVersionResource{
 		Group:    "crd.antrea.io",
-		Version:  "v1alpha1",
+		Version:  "v1beta1",
 		Resource: "traceflows",
 	}
 


### PR DESCRIPTION
v1alpha1 has been removed in Antrea v2.0