### PR TITLE
Use v1 tag for benc-uk/workflow-dispatch Github Action

### DIFF
--- a/.github/workflows/process_release.yml
+++ b/.github/workflows/process_release.yml
@@ -40,7 +40,7 @@ jobs:
         version=${TAG:10}
         echo "version=$version" >> $GITHUB_OUTPUT
     - name: Update Helm index with Antrea UI archive
-      uses: benc-uk/workflow-dispatch@v121
+      uses: benc-uk/workflow-dispatch@v1
       with:
         repo: antrea-io/website
         ref: refs/heads/main


### PR DESCRIPTION
It seems that tag v121 no longer exists. I do not recall why v1 was not used in the first place, but it seems that it is the right thing to do now. antrea-io/antrea also uses v1. This tag will make sure that the latest available release for major version v1 is used, every time the action runs.