### PR TITLE
Bump Kind version from v0.18.0 to v0.22.0

### DIFF
--- a/.github/workflows/kind_e2e.yml
+++ b/.github/workflows/kind_e2e.yml
@@ -10,7 +10,7 @@ on:
     - release-*
 
 env:
-  KIND_VERSION: v0.18.0
+  KIND_VERSION: v0.22.0
 
 jobs:
   check-changes:


### PR DESCRIPTION
The default node image is now Kubernetes 1.29.2