### PR TITLE
Omit zero srcPort / dstPort in Traceflow requests from web client

### DIFF
--- a/client/web/antrea-ui/src/routes/traceflow.test.tsx
+++ b/client/web/antrea-ui/src/routes/traceflow.test.tsx
@@ -207,7 +207,6 @@ describe('Traceflow request', () => {
                     },
                     transportHeader: {
                         tcp: {
-                            srcPort: 0,
                             dstPort: 80,
                             flags: 2,
                         },
@@ -239,10 +238,7 @@ describe('Traceflow request', () => {
                         protocol: 17,
                     },
                     transportHeader: {
-                        udp: {
-                            srcPort: 0,
-                            dstPort: 0,
-                        },
+                        udp: {},
                     },
                 },
                 liveTraffic: true,

--- a/client/web/antrea-ui/src/routes/traceflow.tsx
+++ b/client/web/antrea-ui/src/routes/traceflow.tsx
@@ -64,18 +64,27 @@ function createTraceflowPacket(inputs: Inputs, useIPv6: boolean): TraceflowPacke
             case "TCP": {
                 protocol = 6;
                 packet.transportHeader.tcp = {
-                    srcPort: inputs.srcPort,
-                    dstPort: inputs.dstPort,
                     flags: inputs.tcpFlags,
                 };
+                // A srcPort or dstPort equal to 0 (which has a specific meaning) must be omitted
+                // from the Traceflow API request (since v1beta1), or the request will be rejected.
+                if (inputs.srcPort > 0) {
+                    packet.transportHeader.tcp.srcPort = inputs.srcPort;
+                }
+                if (inputs.dstPort > 0) {
+                    packet.transportHeader.tcp.dstPort = inputs.dstPort;
+                }
                 break;
             }
             case "UDP": {
                 protocol = 17;
-                packet.transportHeader.udp = {
-                    srcPort: inputs.srcPort,
-                    dstPort: inputs.dstPort,
-                };
+                packet.transportHeader.udp = {};
+                if (inputs.srcPort > 0) {
+                    packet.transportHeader.udp.srcPort = inputs.srcPort;
+                }
+                if (inputs.dstPort > 0) {
+                    packet.transportHeader.udp.dstPort = inputs.dstPort;
+                }
                 break;
             }
     }


### PR DESCRIPTION
Starting with v1beta1 of the Traceflow API, it is invalid to explicitly set srcPort / dstPort to 0. 0 is not a valid port value in general, and the UI uses 0 for some special cases (e.g., to tell the server to use a random srcPort for a Traceflow request).