### PR TITLE
Fix Traceflow deletion in web client

### DIFF
--- a/client/web/antrea-ui/src/api/traceflow.test.tsx
+++ b/client/web/antrea-ui/src/api/traceflow.test.tsx
@@ -86,7 +86,9 @@ describe('Traceflow API', () => {
             baseURL: '',
         }));
         if (withDelete) {
-            expect(mock.delete).toHaveBeenCalledWith(`/api/v1/traceflow/${reqId}`, expect.anything());
+            expect(mock.delete).toHaveBeenCalledWith(`/api/v1/traceflow/${reqId}`, expect.objectContaining({
+            baseURL: '',
+        }));
         } else {
             expect(mock.delete).not.toHaveBeenCalled();
         }

--- a/client/web/antrea-ui/src/api/traceflow.tsx
+++ b/client/web/antrea-ui/src/api/traceflow.tsx
@@ -148,6 +148,7 @@ export const traceflowAPI = {
                 if (done) {
                     if (withDelete) {
                         await api.delete(reqURL, {
+                            baseURL: `${apiServer}`,
                             validateStatus: (status: number) => status === 200,
                         }).then(_ => console.log("Traceflow deleted successfully")).catch(_ => console.error("Unable to delete traceflow"));
                     }


### PR DESCRIPTION
After a Traceflow request initiated in the UI completes, we delete the Traceflow resource. This was broken because the wrong base URL was used.