### PR TITLE
Traceflow improvements in web client

### DIFF
--- a/client/web/antrea-ui/src/api/traceflow.tsx
+++ b/client/web/antrea-ui/src/api/traceflow.tsx
@@ -86,6 +86,8 @@ export interface TraceflowObservation {
     translatedDstIP: string
     tunnelDstIP: string
     egressIP: string
+    egressNode: string
+    srcPodIP: string
 }
 
 export interface TraceflowNodeResult {

--- a/client/web/antrea-ui/src/routes/traceflow.tsx
+++ b/client/web/antrea-ui/src/routes/traceflow.tsx
@@ -196,7 +196,7 @@ export default function Traceflow() {
         let dstPort = 0;
         if (!liveTraffic) {
             if (protocol === "TCP") dstPort = 80;
-            else if (protocol === "UDP") dstPort = 43;
+            else if (protocol === "UDP") dstPort = 53;
         }
         let tcpFlags = 0;
         if (protocol === "TCP" && !liveTraffic) {
@@ -281,11 +281,11 @@ export default function Traceflow() {
         {
             min: {
                 value: 0,
-                message: "source port must be >= 0",
+                message: "Source port must be >= 0",
             },
             max: {
                 value: 65535,
-                message: "source port must be <= 65535",
+                message: "Source port must be <= 65535",
             },
             setValueAs: parseInt,
         },
@@ -302,14 +302,15 @@ export default function Traceflow() {
         "dstPort",
         {
             min: {
-                value: 0,
-                message: "destination port must be >= 0",
+                value: isLiveTraffic ? 0 : 1,
+                message: "Destination port must be >= " +  (isLiveTraffic ? 0 : 1).toString(),
             },
             max: {
                 value: 65535,
-                message: "destination port must be <= 65535",
+                message: "Destination port must be <= 65535",
             },
             setValueAs: parseInt,
+            required: !isLiveTraffic && "Destination port is required",
         },
     );
 
@@ -333,11 +334,11 @@ export default function Traceflow() {
         {
             min: {
                 value: 1,
-                message: "timeout must be >= 1",
+                message: "Timeout must be >= 1",
             },
             max: {
                 value: 120,
-                message: "timeout must be <= 120",
+                message: "Timeout must be <= 120",
             },
             setValueAs: parseInt,
         },

--- a/client/web/antrea-ui/src/routes/traceflowresult.tsx
+++ b/client/web/antrea-ui/src/routes/traceflowresult.tsx
@@ -261,6 +261,7 @@ class TraceflowGraphBuilder {
             if (obs.tunnelDstIP) label.push(`Tunnel Destination IP: ${obs.tunnelDstIP}`);
             if (obs.egressIP) label.push(`Egress IP: ${obs.egressIP}`);
             if (obs.egress) label.push(`Egress: ${obs.egress}`);
+            if (obs.egressNode) label.push(`Egress Node: ${obs.egressNode}`);
         }
         return label.join('\n');
     }


### PR DESCRIPTION
* Add egressNode and srcPodIP fields to TraceflowObservation. These fields were added to the API recently. We show egressNode in the generated result graph when appropriate, but we don't use srcPodIP at the moment.
* Use 53 (DNS) as the default port for UDP instead of 43. I believe 43 was a typo...
* More uniform capitalization of error messages for Traceflow form validation.
* Make dstPort required for non-live Traceflow.