### PR TITLE
Fix dstPort validation in Traceflow form

### DIFF
--- a/client/web/antrea-ui/src/routes/traceflow.tsx
+++ b/client/web/antrea-ui/src/routes/traceflow.tsx
@@ -298,19 +298,20 @@ export default function Traceflow() {
         },
     );
 
+    const dstPortRequired = !isLiveTraffic && (proto === "TCP" || proto === "UDP");
     const dstPort = register(
         "dstPort",
         {
             min: {
-                value: isLiveTraffic ? 0 : 1,
-                message: "Destination port must be >= " +  (isLiveTraffic ? 0 : 1).toString(),
+                value: dstPortRequired ? 1 : 0,
+                message: "Destination port must be >= " +  (dstPortRequired ? 1 : 0).toString(),
             },
             max: {
                 value: 65535,
                 message: "Destination port must be <= 65535",
             },
             setValueAs: parseInt,
-            required: !isLiveTraffic && "Destination port is required",
+            required: dstPortRequired && "Destination port is required",
         },
     );
 


### PR DESCRIPTION
The dstPort field is not required for ICMP (the field is actually hidden from the form when ICMP is selected). If we use 1 as the min value for the field unconditionally, somehow the first form submit will succeed, but subsequent ones will fail.