### PR TITLE
Bump axios to 1.7.5

### DIFF
--- a/client/web/antrea-ui/package.json
+++ b/client/web/antrea-ui/package.json
@@ -12,7 +12,7 @@
     "@testing-library/react": "^15.0.7",
     "@testing-library/user-event": "^14.5.2",
     "@vitejs/plugin-react": "^4.3.1",
-    "axios": "^1.7.3",
+    "axios": "^1.7.5",
     "axios-auth-refresh": "^3.3.6",
     "base-64": "^1.0.0",
     "d3": "^7.9.0",

--- a/client/web/antrea-ui/src/api/axios.test.tsx
+++ b/client/web/antrea-ui/src/api/axios.test.tsx
@@ -26,6 +26,8 @@ describe('axios instance', () => {
     const token2 = 'token2';
     const getTokenMock = vi.mocked(getToken);
     const setTokenMock = vi.mocked(setToken);
+    // Default base URL used by axios.
+    const origin = window.location.href;
 
     afterAll(() => {
         vi.restoreAllMocks();
@@ -35,7 +37,7 @@ describe('axios instance', () => {
     });
 
     test('valid token', async () => {
-        const scope = nock('http://localhost', {
+        const scope = nock(origin, {
             reqheaders: {
                 'Authorization': `Bearer ${token1}`,
             },
@@ -43,7 +45,7 @@ describe('axios instance', () => {
 
         getTokenMock.mockReturnValueOnce(token1);
 
-        await api.get('test');
+        await api.get('/test');
 
         // Assert that the expected request was made.
         scope.done();
@@ -52,7 +54,7 @@ describe('axios instance', () => {
     });
 
     test('expired token', async () => {
-        const scope = nock('http://localhost')
+        const scope = nock(origin)
             .get('/api/v1/test').matchHeader('Authorization', `Bearer ${token1}`).reply(401, 'expired token')
             .get('/auth/refresh_token').reply(200, JSON.stringify({
                 accessToken: token2,
@@ -76,7 +78,7 @@ describe('axios instance', () => {
     });
 
     test('failed refresh', async () => {
-        const scope = nock('http://localhost')
+        const scope = nock(origin)
             .get('/api/v1/test').matchHeader('Authorization', `Bearer ${token1}`).reply(401, 'expired token')
             .get('/auth/refresh_token').reply(500, 'unknown error');
 
@@ -91,7 +93,7 @@ describe('axios instance', () => {
     });
 
     test('failed refresh with unauthenticated', async () => {
-        const scope = nock('http://localhost')
+        const scope = nock(origin)
             .get('/api/v1/test').matchHeader('Authorization', `Bearer ${token1}`).reply(401, 'expired token')
             .get('/auth/refresh_token').reply(401, 'expired cookie');
 

--- a/client/web/antrea-ui/yarn.lock
+++ b/client/web/antrea-ui/yarn.lock
@@ -1476,10 +1476,10 @@ axios-auth-refresh@^3.3.6:
   resolved "https://registry.yarnpkg.com/axios-auth-refresh/-/axios-auth-refresh-3.3.6.tgz#a879f6296a889d6616e51069c2a8135b697966e7"
   integrity sha512-2CeBUce/SxIfFxow5/n8vApJ97yYF6qoV4gh1UrswT7aEOnlOdBLxxyhOI4IaxGs6BY0l8YujU2jlc4aCmK17Q==
 
-axios@^1.7.3:
-  version "1.7.3"
-  resolved "https://registry.yarnpkg.com/axios/-/axios-1.7.3.tgz#a1125f2faf702bc8e8f2104ec3a76fab40257d85"
-  integrity sha512-Ar7ND9pU99eJ9GpoGQKhKf58GpUOgnzuaB7ueNQ5BMi0p+LZ5oaEnfF999fAArcTIBwXTCHAmGcHOZJaWPq9Nw==
+axios@^1.7.5:
+  version "1.7.5"
+  resolved "https://registry.yarnpkg.com/axios/-/axios-1.7.5.tgz#21eed340eb5daf47d29b6e002424b3e88c8c54b1"
+  integrity sha512-fZu86yCo+svH3uqJ/yTdQ0QHpQu5oL+/QE+QPSv6BZSkDAoky9vytxp7u5qk83OJFS3kEBcesWni9WTZAv3tSw==
   dependencies:
     follow-redirects "^1.15.6"
     form-data "^4.0.0"


### PR DESCRIPTION
The base URL for relative URLs no longer defaults to http://localhost but now defaults to the "origin" (window.location.href). This led to some Node test failures. There are several ways to address this, but we chose to simply use the origin as the URL for the nock test server.