### PR TITLE
Ignore major version updates for @types/node in Dependabot (npm)

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -28,3 +28,7 @@ updates:
     schedule:
       interval: "weekly"
     open-pull-requests-limit: 10
+    ignore:
+    # Should we updated alongside the Node version used for building and testing
+    - dependency-name: "@types/node"
+      update-types: ["version-update:semver-major"]


### PR DESCRIPTION
Package version should be updated alongside the Node version used for building and testing.