### PR TITLE
Add release.yml to exclude renovate[bot] from changelogs

### DIFF
--- a/.github/release.yml
+++ b/.github/release.yml
@@ -1,0 +1,4 @@
+changelog:
+  exclude:
+    authors:
+      - renovate[bot]


### PR DESCRIPTION
## Summary

- Add `.github/release.yml` to configure GitHub's auto-generated release notes
- Excludes contributions from `renovate[bot]` so dependency bump PRs don't clutter the release changelog