### PR TITLE
Update Go to 1.26 and upgrade golangci-lint to v2.12.2

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -11,6 +11,12 @@ linters:
     - staticcheck
     - unused
   settings:
+    gosec:
+      excludes:
+        # G124: http.Cookie missing or has insecure Secure, HttpOnly, or SameSite attribute
+        # Some cookie attributes are intentionally configurable (e.g., Secure), and this rule
+        # creates a lot of noise (it would require a lot of nosec overrides).
+        - G124
     revive:
       confidence: 0.8
       severity: warning

--- a/Makefile
+++ b/Makefile
@@ -8,7 +8,7 @@ BINDIR := $(CURDIR)/bin
 GOMOCK_VERSION := $(shell grep '^\s*github.com\/golang\/mock\sv\S*$$' go.mod | awk '{print $$2}')
 GOMOCK_BINDIR  := .mockgen-bin
 GOMOCK_BIN     := $(GOMOCK_BINDIR)/$(GOMOCK_VERSION)/mockgen
-GOLANGCI_LINT_VERSION := v2.6.2
+GOLANGCI_LINT_VERSION := v2.12.2
 GOLANGCI_LINT_BINDIR  := .golangci-bin
 GOLANGCI_LINT_BIN     := $(GOLANGCI_LINT_BINDIR)/$(GOLANGCI_LINT_VERSION)/golangci-lint
 
@@ -33,7 +33,7 @@ test:
 $(GOLANGCI_LINT_BIN):
 	@echo "===> Installing Golangci-lint <==="
 	@rm -rf $(GOLANGCI_LINT_BINDIR)/* # delete old versions
-	@curl -sSfL https://raw.githubusercontent.com/golangci/golangci-lint/master/install.sh | sh -s -- -b $(GOLANGCI_LINT_BINDIR)/$(GOLANGCI_LINT_VERSION) $(GOLANGCI_LINT_VERSION)
+	@curl -sSfL https://raw.githubusercontent.com/golangci/golangci-lint/$(GOLANGCI_LINT_VERSION)/install.sh | sh -s -- -b $(GOLANGCI_LINT_BINDIR)/$(GOLANGCI_LINT_VERSION) $(GOLANGCI_LINT_VERSION)
 
 .PHONY: golangci
 golangci: $(GOLANGCI_LINT_BIN)

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module antrea.io/antrea-ui
 
-go 1.25.0
+go 1.26.0
 
 require (
 	github.com/blang/semver v3.5.1+incompatible

--- a/test/e2e_helm/install_test.go
+++ b/test/e2e_helm/install_test.go
@@ -117,9 +117,9 @@ stringData:
 				"auth.oidc.enable":                     "true",
 				"auth.oidc.issuerURL":                  "https://samples.auth0.com/",
 				"auth.oidc.clientIDSecretRef.name":     "test-oidc-credentials",
-				"auth.oidc.clientIDSecretRef.key":      "clientID",
+				"auth.oidc.clientIDSecretRef.key":      "clientID", // #nosec G101: secret ref key name, not a credential
 				"auth.oidc.clientSecretSecretRef.name": "test-oidc-credentials",
-				"auth.oidc.clientSecretSecretRef.key":  "clientSecret",
+				"auth.oidc.clientSecretSecretRef.key":  "clientSecret", // #nosec G101: secret ref key name, not a credential
 			},
 			checks: checkAPIAccess("http", nil),
 		},


### PR DESCRIPTION
Bump the Go version in go.mod from 1.25 to 1.26.

Upgrade golangci-lint from v2.6.2 to v2.12.2 and pin the install script URL to the tagged release ref instead of the "main" branch. Add a gosec exclusion for G124 (http.Cookie security attributes) to reduce noise from intentionally configurable cookie settings. Add `#nosec G101` annotations on the specific value lines that gosec flags in the e2e test, with a justification clarifying these are secret reference key names rather than hardcoded credentials.