### PR TITLE
Support custom npm registry in frontend Docker build

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -62,9 +62,11 @@ clean:
 	rm -rf $(GOLANGCI_LINT_BINDIR)
 	rm -rf $(GOMOCK_BINDIR)
 
+NPM_REGISTRY ?=
+
 .PHONY: build-frontend
 build-frontend:
-	docker build --pull -t antrea/antrea-ui-frontend:$(DOCKER_IMG_VERSION) -f build/frontend.dockerfile --build-arg GO_VERSION=$(GO_VERSION) .
+	docker build --pull -t antrea/antrea-ui-frontend:$(DOCKER_IMG_VERSION) -f build/frontend.dockerfile --build-arg GO_VERSION=$(GO_VERSION) $(if $(NPM_REGISTRY),--build-arg NPM_REGISTRY=$(NPM_REGISTRY)) .
 	docker tag antrea/antrea-ui-frontend:$(DOCKER_IMG_VERSION) antrea/antrea-ui-frontend
 
 .PHONY: build-backend

--- a/build/frontend.dockerfile
+++ b/build/frontend.dockerfile
@@ -21,6 +21,13 @@ COPY client/web/antrea-ui/yarn.lock .
 COPY client/web/antrea-ui/.yarnrc.yml .
 COPY client/web/antrea-ui/.yarn ./.yarn
 
+# Optional: override the npm registry (e.g., for corporate proxies).
+# Leave unset to use the default registry (npmjs.org).
+ARG NPM_REGISTRY=""
+RUN if [ -n "$NPM_REGISTRY" ]; then \
+      echo "npmRegistryServer: \"$NPM_REGISTRY\"" >> .yarnrc.yml; \
+    fi
+
 RUN corepack enable && yarn install --immutable
 
 COPY client/web/antrea-ui .


### PR DESCRIPTION
Add an optional NPM_REGISTRY build argument to the frontend Dockerfile. When set, it appends a `npmRegistryServer` entry to .yarnrc.yml before running `yarn install`, routing package downloads through the specified registry proxy.

The Makefile exposes NPM_REGISTRY as an optional variable (defaults to empty). When unset, the build behaves exactly as before, using the default npm registry. OSS contributors need no changes.

To use a custom registry:
  NPM_REGISTRY=https://your-proxy/npm/ make build-frontend