### PR TITLE
Fix pod label lookup in service map

### DIFF
--- a/client/web/antrea-ui/src/api/flow-types.ts
+++ b/client/web/antrea-ui/src/api/flow-types.ts
@@ -76,9 +76,8 @@ export interface IP {
     destination: string;
 }
 
-export interface Labels {
-    labels: Record<string, string>;
-}
+// Pod labels are serialized as a flat map[string]string by the backend.
+export type Labels = Record<string, string>;
 
 export interface Kubernetes {
     flowType: FlowType;

--- a/client/web/antrea-ui/src/routes/servicemap.tsx
+++ b/client/web/antrea-ui/src/routes/servicemap.tsx
@@ -37,10 +37,10 @@ const WELL_KNOWN_APP_LABELS = [
 ];
 
 function getWorkloadName(namespace: string, podName: string, podLabels?: Labels): string {
-    if (podLabels?.labels) {
+    if (podLabels) {
         for (const label of WELL_KNOWN_APP_LABELS) {
-            if (podLabels.labels[label]) {
-                return `${namespace}/${podLabels.labels[label]}`;
+            if (podLabels[label]) {
+                return `${namespace}/${podLabels[label]}`;
             }
         }
     }


### PR DESCRIPTION
Currently the backend fetched pod labels cannot be retrieved by the UI frontend because of a type mismatch.

The Labels type was defined as a nested struct { labels: Record<string,string> } but the backend serializes sourcePodLabels/destinationPodLabels as a flat map[string]string. This caused getWorkloadName to always fall back to the stripped pod name instead of using the app label from the pod.

Fix by changing Labels to a flat type alias (Record<string,string>) and updating the accessor in getWorkloadName accordingly.