### PR TITLE
feat(dashboard): adding a dedicated dashboard

### DIFF
--- a/build/charts/antrea-ui/templates/clusterrole.yaml
+++ b/build/charts/antrea-ui/templates/clusterrole.yaml
@@ -19,6 +19,13 @@ rules:
       - list
       - get
   - apiGroups:
+      - stats.antrea.io
+    resources:
+      - nodelatencystats
+    verbs:
+      - list
+      - get
+  - apiGroups:
       - crd.antrea.io
     resources:
       - traceflows

--- a/client/web/antrea-ui/src/api/nodelatency.tsx
+++ b/client/web/antrea-ui/src/api/nodelatency.tsx
@@ -1,0 +1,48 @@
+/**
+ * Copyright 2026 Antrea Authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import api from './axios';
+import { handleError } from './common';
+
+export interface TargetIPLatencyStats {
+    targetIP: string
+    lastSendTime?: string
+    lastRecvTime?: string
+    lastMeasuredRTTNanoseconds?: number
+}
+
+export interface PeerNodeLatencyStats {
+    nodeName: string
+    targetIPLatencyStats?: TargetIPLatencyStats[]
+}
+
+export interface NodeLatencyStats {
+    metadata: {
+        name: string
+    }
+    peerNodeLatencyStats?: PeerNodeLatencyStats[]
+}
+
+export const nodeLatencyStatsAPI = {
+    fetchAll: async (): Promise<NodeLatencyStats[]> => {
+        return api.get<{ items: NodeLatencyStats[] }>(
+            `k8s/apis/stats.antrea.io/v1alpha1/nodelatencystats`,
+        ).then((response) => response.data.items).catch((error) => {
+            console.error("Unable to fetch Node Latency Stats");
+            handleError(error);
+        });
+    },
+};

--- a/client/web/antrea-ui/src/components/nav.tsx
+++ b/client/web/antrea-ui/src/components/nav.tsx
@@ -24,6 +24,7 @@ import {
     dashboardIcon, dashboardIconName,
     bugIcon, bugIconName,
     eyeIcon, eyeIconName,
+    nodesIcon, nodesIconName,
  } from '@cds/core/icon';
 
 ClarityIcons.addIcons(
@@ -31,6 +32,7 @@ ClarityIcons.addIcons(
     dashboardIcon,
     bugIcon,
     eyeIcon,
+    nodesIcon,
 );
 
 export default function NavTab() {
@@ -55,6 +57,12 @@ export default function NavTab() {
                 <Link to="/flows">
                     <CdsIcon shape={eyeIconName} solid size="sm"></CdsIcon>
                     Flow Visibility
+                </Link>
+            </CdsNavigationItem>
+            <CdsNavigationItem>
+                <Link to="/nodelatency">
+                    <CdsIcon shape={nodesIconName} solid size="sm"></CdsIcon>
+                    Node Latency
                 </Link>
             </CdsNavigationItem>
             <CdsNavigationItem>

--- a/client/web/antrea-ui/src/components/nodelatency-detail.tsx
+++ b/client/web/antrea-ui/src/components/nodelatency-detail.tsx
@@ -1,0 +1,144 @@
+/**
+ * Copyright 2026 Antrea Authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { CdsCard } from '@cds/react/card';
+import { CdsButton } from '@cds/react/button';
+import { CdsDivider } from '@cds/react/divider';
+import { NodeLink, NodeLatencyModel, nodeLinksFor } from '../routes/nodelatency-util';
+
+function fmtRtt(link: NodeLink): string {
+    return link.down || link.rttMs === undefined ? 'N/A' : link.rttMs.toFixed(3);
+}
+
+function latestRecv(link: NodeLink): string {
+    const times = link.targets.map(t => t.lastRecvTime).filter((t): t is string => !!t).sort();
+    const t = times.length ? times[times.length - 1] : undefined;
+    return t ? new Date(t).toLocaleString() : 'None';
+}
+
+function targetIPs(link: NodeLink): string {
+    return link.targets.map(t => t.targetIP).join(', ') || 'None';
+}
+
+function LinkTable(props: { title: string, peerHeader: string, links: NodeLink[], peerOf: (l: NodeLink) => string }) {
+    return (
+        <div cds-layout="vertical gap:sm">
+            <div cds-text="section">{props.title}</div>
+            {props.links.length === 0 ? (
+                <p cds-text="secondary">No {props.title.toLowerCase()}.</p>
+            ) : (
+                <table cds-table="border:all" cds-text="center body">
+                    <thead>
+                        <tr>
+                            <th>{props.peerHeader}</th>
+                            <th>Status</th>
+                            <th>Latency (ms)</th>
+                            <th>Target IP</th>
+                            <th>Last Recv</th>
+                        </tr>
+                    </thead>
+                    <tbody>
+                        {props.links.map((link, idx) => (
+                            <tr key={idx}>
+                                <td>{props.peerOf(link)}</td>
+                                <td style={link.down ? { color: '#e12200' } : undefined}>{link.down ? 'Down' : 'Up'}</td>
+                                <td>{fmtRtt(link)}</td>
+                                <td>{targetIPs(link)}</td>
+                                <td>{latestRecv(link)}</td>
+                            </tr>
+                        ))}
+                    </tbody>
+                </table>
+            )}
+        </div>
+    );
+}
+
+export function NodeDetailPanel(props: { model: NodeLatencyModel, node: string, onClose: () => void }) {
+    const { egress, ingress } = nodeLinksFor(props.model.links, props.node);
+    const health = props.model.health.get(props.node);
+
+    return (
+        <CdsCard>
+            <div cds-layout="vertical gap:md">
+                <div cds-layout="horizontal align:vertical-center gap:md">
+                    <div cds-text="section" cds-layout="align:left">Node: {props.node}</div>
+                    <CdsButton type="button" action="outline" size="sm" onClick={props.onClose}>Clear</CdsButton>
+                </div>
+                {health && (
+                    <p cds-text="secondary">
+                        Egress: {health.egressTotal - health.egressDown}/{health.egressTotal} up
+                        {' '}&middot;{' '}
+                        Ingress: {health.ingressTotal - health.ingressDown}/{health.ingressTotal} up
+                    </p>
+                )}
+                <CdsDivider cds-card-remove-margin></CdsDivider>
+                <LinkTable
+                    title="Egress Links"
+                    peerHeader="Target Node"
+                    links={egress}
+                    peerOf={l => l.targetNode}
+                />
+                <LinkTable
+                    title="Ingress Links"
+                    peerHeader="Source Node"
+                    links={ingress}
+                    peerOf={l => l.sourceNode}
+                />
+            </div>
+        </CdsCard>
+    );
+}
+
+export function ProblemNodesPanel(props: { model: NodeLatencyModel, onSelect: (node: string) => void }) {
+    const problems = props.model.problemNodes;
+    if (problems.length === 0) return null;
+
+    return (
+        <CdsCard>
+            <div cds-layout="vertical gap:md">
+                <div cds-text="section" style={{ color: '#e12200' }}>
+                    Problem Nodes ({problems.length})
+                </div>
+                <CdsDivider cds-card-remove-margin></CdsDivider>
+                <table cds-table="border:all" cds-text="center body">
+                    <thead>
+                        <tr>
+                            <th>Node</th>
+                            <th>Egress Down</th>
+                            <th>Ingress Down</th>
+                            <th></th>
+                        </tr>
+                    </thead>
+                    <tbody>
+                        {problems.map(h => (
+                            <tr key={h.node}>
+                                <td>{h.node}</td>
+                                <td>{h.egressDown}/{h.egressTotal}</td>
+                                <td>{h.ingressDown}/{h.ingressTotal}</td>
+                                <td>
+                                    <CdsButton type="button" action="flat" size="sm" onClick={() => props.onSelect(h.node)}>
+                                        Inspect
+                                    </CdsButton>
+                                </td>
+                            </tr>
+                        ))}
+                    </tbody>
+                </table>
+            </div>
+        </CdsCard>
+    );
+}

--- a/client/web/antrea-ui/src/components/nodelatency-stats.tsx
+++ b/client/web/antrea-ui/src/components/nodelatency-stats.tsx
@@ -1,0 +1,54 @@
+/**
+ * Copyright 2026 Antrea Authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { CdsCard } from '@cds/react/card';
+import { CdsDivider } from '@cds/react/divider';
+import { AggregatedStats } from '../routes/nodelatency-util';
+
+function fmt(v: number): string {
+    return isNaN(v) ? 'N/A' : v.toFixed(2);
+}
+
+export default function NodeLatencyStatsSummary(props: { agg: AggregatedStats }) {
+    const a = props.agg;
+    const items: { label: string, value: string, alert?: boolean }[] = [
+        { label: 'Nodes', value: a.nodeCount.toString() },
+        { label: 'Measured Links', value: a.measuredCount.toString() },
+        { label: 'Down Links', value: a.downCount.toString(), alert: a.downCount > 0 },
+        { label: 'Mean (ms)', value: fmt(a.meanMs) },
+        { label: 'Median (ms)', value: fmt(a.medianMs) },
+        { label: 'P90 (ms)', value: fmt(a.p90Ms) },
+        { label: 'Max (ms)', value: fmt(a.maxMs) },
+    ];
+    return (
+        <CdsCard>
+            <div cds-layout="vertical gap:md">
+                <div cds-text="section" cds-layout="p-y:sm">Summary</div>
+                <CdsDivider cds-card-remove-margin></CdsDivider>
+                <div cds-layout="horizontal gap:xl wrap:wrap p-y:sm">
+                    {items.map(item => (
+                        <div key={item.label} cds-layout="vertical gap:xs">
+                            <div cds-text="caption" style={{ opacity: 0.7 }}>{item.label}</div>
+                            <div cds-text="heading" style={item.alert ? { color: '#e12200' } : undefined}>
+                                {item.value}
+                            </div>
+                        </div>
+                    ))}
+                </div>
+            </div>
+        </CdsCard>
+    );
+}

--- a/client/web/antrea-ui/src/index.tsx
+++ b/client/web/antrea-ui/src/index.tsx
@@ -24,6 +24,7 @@ import Summary from './routes/summary';
 import Traceflow from './routes/traceflow';
 import TraceflowResult from './routes/traceflowresult';
 import FlowVisibility from './routes/flowvisibility';
+import NodeLatency from './routes/nodelatency';
 import Settings from './routes/settings';
 import reportWebVitals from './reportWebVitals';
 
@@ -54,6 +55,10 @@ const router = createBrowserRouter([
             {
                 path: "flows",
                 element: <FlowVisibility />,
+            },
+            {
+                path: "nodelatency",
+                element: <NodeLatency />,
             },
             {
                 path: "settings",

--- a/client/web/antrea-ui/src/routes/nodelatency-heatmap.tsx
+++ b/client/web/antrea-ui/src/routes/nodelatency-heatmap.tsx
@@ -1,0 +1,193 @@
+/**
+ * Copyright 2026 Antrea Authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { useRef, useEffect, useState, useMemo } from 'react';
+import { CdsCard } from '@cds/react/card';
+import { NodeLink, NodeLatencyModel, heatmapNodeOrder, linkKey } from './nodelatency-util';
+
+// Matches the green→yellow→red gradient from the original ECharts config.
+const C_FAST: [number, number, number] = [90, 167, 0];
+const C_MID: [number, number, number] = [253, 185, 19];
+const C_SLOW: [number, number, number] = [225, 34, 0];
+const C_DOWN: [number, number, number] = [79, 85, 98];
+
+function lerp(a: number, b: number, t: number): number {
+    return Math.round(a + (b - a) * t);
+}
+
+function rttToRgb(rttMs: number, minRtt: number, maxRtt: number): [number, number, number] {
+    const t = maxRtt > minRtt ? (rttMs - minRtt) / (maxRtt - minRtt) : 0;
+    const [lo, hi, s] = t <= 0.5 ? [C_FAST, C_MID, t * 2] : [C_MID, C_SLOW, (t - 0.5) * 2];
+    return [lerp(lo[0], hi[0], s), lerp(lo[1], hi[1], s), lerp(lo[2], hi[2], s)];
+}
+
+// Maximum canvas side in logical pixels. cellPx = floor(MAX_CANVAS_PX / n), so
+// total pixel writes are always O(MAX_CANVAS_PX²) regardless of cluster size.
+// For n > MAX_CANVAS_PX, cellPx clamps to 1 and the browser CSS-scales the canvas
+// down to fit — structural patterns (full row/column down) remain visible.
+const MAX_CANVAS_PX = 1000;
+
+interface TooltipState {
+    clientX: number;
+    clientY: number;
+    source: string;
+    target: string;
+    self: boolean;
+    link?: NodeLink;
+}
+
+export default function NodeLatencyHeatmap(props: { model: NodeLatencyModel; restrictToProblem?: boolean }) {
+    const { model, restrictToProblem } = props;
+    const canvasRef = useRef<HTMLCanvasElement>(null);
+    const [tooltip, setTooltip] = useState<TooltipState | null>(null);
+
+    const nodes = useMemo(
+        () => heatmapNodeOrder(model, restrictToProblem ?? false),
+        [model, restrictToProblem],
+    );
+    const n = nodes.length;
+
+    const { buf, canvasSize, cellPx } = useMemo(() => {
+        if (n === 0) return { buf: null as Uint8ClampedArray | null, canvasSize: 0, cellPx: 1 };
+
+        const cellPx = Math.max(1, Math.floor(MAX_CANVAS_PX / n));
+        const canvasSize = n * cellPx;
+        const buf = new Uint8ClampedArray(canvasSize * canvasSize * 4);
+
+        let minRtt = Infinity, maxRtt = 0;
+        for (let y = 0; y < n; y++) {
+            for (let x = 0; x < n; x++) {
+                if (x === y) continue;
+                const link = model.linkByKey.get(linkKey(nodes[y], nodes[x]));
+                if (link && !link.down && link.rttMs !== undefined) {
+                    if (link.rttMs < minRtt) minRtt = link.rttMs;
+                    if (link.rttMs > maxRtt) maxRtt = link.rttMs;
+                }
+            }
+        }
+        if (minRtt === Infinity) minRtt = 0;
+
+        for (let y = 0; y < n; y++) {
+            for (let x = 0; x < n; x++) {
+                let r = 0, g = 0, b = 0, a = 0;
+                if (x !== y) {
+                    const link = model.linkByKey.get(linkKey(nodes[y], nodes[x]));
+                    if (!link) {
+                        [r, g, b] = [0x20, 0x22, 0x26]; a = 255;
+                    } else if (link.down || link.rttMs === undefined) {
+                        [r, g, b] = C_DOWN; a = 255;
+                    } else {
+                        [r, g, b] = rttToRgb(link.rttMs, minRtt, maxRtt); a = 255;
+                    }
+                }
+                for (let py = y * cellPx; py < (y + 1) * cellPx; py++) {
+                    for (let px = x * cellPx; px < (x + 1) * cellPx; px++) {
+                        const i = 4 * (py * canvasSize + px);
+                        buf[i] = r; buf[i + 1] = g; buf[i + 2] = b; buf[i + 3] = a;
+                    }
+                }
+            }
+        }
+        return { buf, canvasSize, cellPx };
+    }, [nodes, model, n]);
+
+    useEffect(() => {
+        const canvas = canvasRef.current;
+        if (!canvas || !buf || canvasSize === 0) return;
+        canvas.width = canvasSize;
+        canvas.height = canvasSize;
+        const ctx = canvas.getContext('2d');
+        if (!ctx) return;
+        const imageData = ctx.createImageData(canvasSize, canvasSize);
+        imageData.data.set(buf);
+        ctx.putImageData(imageData, 0, 0);
+    }, [buf, canvasSize]);
+
+    const handleMouseMove = (e: React.MouseEvent<HTMLCanvasElement>) => {
+        const canvas = canvasRef.current;
+        if (!canvas || n === 0) return;
+        const rect = canvas.getBoundingClientRect();
+        const xi = Math.floor(((e.clientX - rect.left) * canvasSize / rect.width) / cellPx);
+        const yi = Math.floor(((e.clientY - rect.top) * canvasSize / rect.height) / cellPx);
+        if (xi < 0 || xi >= n || yi < 0 || yi >= n) { setTooltip(null); return; }
+        const source = nodes[yi], target = nodes[xi];
+        setTooltip({
+            clientX: e.clientX,
+            clientY: e.clientY,
+            source,
+            target,
+            self: xi === yi,
+            link: xi === yi ? undefined : model.linkByKey.get(linkKey(source, target)),
+        });
+    };
+
+    const truncated = restrictToProblem && nodes.length < model.nodes.length
+        ? { shown: nodes.length, total: model.nodes.length } : null;
+
+    return (
+        <CdsCard>
+            <div cds-layout="vertical gap:sm">
+                {truncated && (
+                    <p cds-text="secondary">
+                        Showing problem nodes only ({truncated.shown} of {truncated.total}).
+                    </p>
+                )}
+                {n === 0 ? (
+                    <p cds-text="secondary">No active nodes found.</p>
+                ) : (
+                    <div>
+                        <canvas
+                            ref={canvasRef}
+                            style={{ maxWidth: '100%', display: 'block', cursor: 'crosshair' }}
+                            onMouseMove={handleMouseMove}
+                            onMouseLeave={() => setTooltip(null)}
+                        />
+                        {tooltip && (
+                            <div style={{
+                                position: 'fixed',
+                                left: tooltip.clientX + 14,
+                                top: tooltip.clientY + 14,
+                                background: 'rgba(20,20,20,0.9)',
+                                color: '#fff',
+                                padding: '4px 8px',
+                                borderRadius: 4,
+                                fontSize: 12,
+                                lineHeight: 1.5,
+                                pointerEvents: 'none',
+                                zIndex: 9999,
+                            }}>
+                                <div>{tooltip.source} &rarr; {tooltip.target}</div>
+                                {tooltip.self ? null
+                                    : !tooltip.link ? <div style={{ opacity: 0.6 }}>No measurement</div>
+                                    : tooltip.link.down ? <div style={{ color: '#ff7070' }}>Down</div>
+                                    : <div>{(tooltip.link.rttMs ?? 0).toFixed(3)} ms</div>
+                                }
+                            </div>
+                        )}
+                    </div>
+                )}
+                <div style={{ display: 'flex', gap: 6, alignItems: 'center', fontSize: 11, opacity: 0.65 }}>
+                    <span style={{ width: 12, height: 12, borderRadius: 2, background: '#5aa700', flexShrink: 0, display: 'inline-block' }} />
+                    Fast
+                    <div style={{ width: 60, height: 10, borderRadius: 2, background: 'linear-gradient(to right, #5aa700, #fdb913, #e12200)', flexShrink: 0 }} />
+                    Slow
+                    <span style={{ marginLeft: 4, width: 12, height: 12, borderRadius: 2, background: '#4f5562', flexShrink: 0, display: 'inline-block' }} />
+                    Down
+                </div>
+            </div>
+        </CdsCard>
+    );
+}

--- a/client/web/antrea-ui/src/routes/nodelatency-util.test.ts
+++ b/client/web/antrea-ui/src/routes/nodelatency-util.test.ts
@@ -1,0 +1,211 @@
+/**
+ * Copyright 2026 Antrea Authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { NodeLatencyStats } from '../api/nodelatency';
+import {
+    DOWN_STALENESS_MS,
+    aggregateStats,
+    buildLinks,
+    buildModel,
+    heatmapNodeOrder,
+    mean,
+    median,
+    nodeHealthMap,
+    nodeLinksFor,
+    nodeNames,
+    percentile,
+    problemNodes,
+    rankNodes,
+    referenceTime,
+} from './nodelatency-util';
+
+describe('statistics helpers', () => {
+    test('mean', () => {
+        expect(mean([2, 4, 6])).toBe(4);
+        expect(mean([])).toBeNaN();
+    });
+
+    test('median', () => {
+        expect(median([3, 1, 2])).toBe(2);
+        expect(median([1, 2, 3, 4])).toBe(2.5);
+        expect(median([5])).toBe(5);
+    });
+
+    test('percentile interpolates', () => {
+        expect(percentile([10, 20, 30, 40], 90)).toBeCloseTo(37, 5);
+        expect(percentile([10, 20, 30, 40], 0)).toBe(10);
+        expect(percentile([10, 20, 30, 40], 100)).toBe(40);
+        expect(percentile([], 50)).toBeNaN();
+    });
+});
+
+// Use dynamic timestamps so all fixtures are within the staleness window when the tests run.
+const BASE_TIME = Date.now();
+const sendTime = new Date(BASE_TIME - 30_000).toISOString();   // 30 s ago
+const recvTime = new Date(BASE_TIME - 60_000).toISOString();   // 60 s ago
+// A reply received well past the staleness window relative to now.
+const staleRecvTime = new Date(BASE_TIME - DOWN_STALENESS_MS - 60_000).toISOString();
+
+const stats: NodeLatencyStats[] = [
+    {
+        metadata: { name: 'node-a' },
+        peerNodeLatencyStats: [
+            {
+                nodeName: 'node-b',
+                targetIPLatencyStats: [
+                    { targetIP: '10.0.0.2', lastMeasuredRTTNanoseconds: 2_000_000, lastSendTime: sendTime, lastRecvTime: recvTime },
+                ],
+            },
+            {
+                nodeName: 'node-c',
+                targetIPLatencyStats: [
+                    // RTT present but reply is stale -> down.
+                    { targetIP: '10.0.0.3', lastMeasuredRTTNanoseconds: 9_000_000, lastSendTime: sendTime, lastRecvTime: staleRecvTime },
+                ],
+            },
+        ],
+    },
+    {
+        metadata: { name: 'node-b' },
+        peerNodeLatencyStats: [
+            {
+                nodeName: 'node-a',
+                targetIPLatencyStats: [
+                    // Missing RTT -> down.
+                    { targetIP: '10.0.0.1', lastSendTime: sendTime },
+                    { targetIP: 'fd00::1', lastMeasuredRTTNanoseconds: 4_000_000, lastSendTime: sendTime, lastRecvTime: recvTime },
+                ],
+            },
+        ],
+    },
+];
+
+describe('node latency aggregation', () => {
+    test('nodeNames returns the sorted union of sources and peers', () => {
+        expect(nodeNames(stats)).toEqual(['node-a', 'node-b', 'node-c']);
+    });
+
+    test('referenceTime is at least the current time', () => {
+        // sendTime is 30 s in the past, so Date.now() wins and the result must
+        // be >= the time we started the test.
+        expect(referenceTime(stats)).toBeGreaterThanOrEqual(BASE_TIME);
+    });
+
+    test('buildLinks collapses target IPs to the max up RTT and flags down links', () => {
+        const links = buildLinks(stats);
+        const ab = links.find(l => l.sourceNode === 'node-a' && l.targetNode === 'node-b')!;
+        expect(ab.down).toBe(false);
+        expect(ab.rttMs).toBe(2);
+
+        const ac = links.find(l => l.sourceNode === 'node-a' && l.targetNode === 'node-c')!;
+        expect(ac.down).toBe(true);
+
+        // node-b -> node-a has one down (missing RTT) and one up (4ms) target; link is up at 4ms.
+        const ba = links.find(l => l.sourceNode === 'node-b' && l.targetNode === 'node-a')!;
+        expect(ba.down).toBe(false);
+        expect(ba.rttMs).toBe(4);
+    });
+
+    test('aggregateStats summarises only up links', () => {
+        const agg = aggregateStats(stats);
+        expect(agg.nodeCount).toBe(3);
+        expect(agg.measuredCount).toBe(2);
+        expect(agg.downCount).toBe(1);
+        expect(agg.meanMs).toBe(3);
+        expect(agg.maxMs).toBe(4);
+    });
+});
+
+describe('node health and problem detection', () => {
+    test('nodeHealthMap counts ingress/egress totals and down links', () => {
+        const links = buildLinks(stats);
+        const health = nodeHealthMap(links, nodeNames(stats));
+        const a = health.get('node-a')!;
+        expect(a).toMatchObject({ egressTotal: 2, egressDown: 1, ingressTotal: 1, ingressDown: 0, maxRttMs: 4 });
+        const c = health.get('node-c')!;
+        expect(c).toMatchObject({ egressTotal: 0, egressDown: 0, ingressTotal: 1, ingressDown: 1, maxRttMs: 0 });
+    });
+
+    test('problemNodes applies the down threshold', () => {
+        const health = nodeHealthMap(buildLinks(stats), nodeNames(stats));
+        expect(problemNodes(health, 2)).toHaveLength(0);
+        expect(problemNodes(health, 1).map(h => h.node)).toEqual(['node-a', 'node-c']);
+    });
+
+    test('rankNodes orders by down count then latency', () => {
+        const health = nodeHealthMap(buildLinks(stats), nodeNames(stats));
+        expect(rankNodes(nodeNames(stats), health)).toEqual(['node-a', 'node-c', 'node-b']);
+    });
+
+    test('nodeLinksFor splits egress and ingress for a node', () => {
+        const { egress, ingress } = nodeLinksFor(buildLinks(stats), 'node-a');
+        expect(egress.map(l => l.targetNode).sort()).toEqual(['node-b', 'node-c']);
+        expect(ingress.map(l => l.sourceNode)).toEqual(['node-b']);
+    });
+
+    test('buildModel exposes a coherent shared model', () => {
+        const model = buildModel(stats, 1);
+        expect(model.agg.nodeCount).toBe(3);
+        expect(model.problemNodeSet.has('node-a')).toBe(true);
+        expect(model.rankedNodes[0]).toBe('node-a');
+        expect(model.linkByKey.get('node-a|node-b')?.rttMs).toBe(2);
+    });
+});
+
+describe('large cluster scaling', () => {
+    // Ring of 300 nodes (each up-link to the next), with node000 also failing to reach
+    // three peers so it is the highest-severity node.
+    function makeLargeCluster(n: number): NodeLatencyStats[] {
+        const name = (i: number) => `node${String(i).padStart(3, '0')}`;
+        const out: NodeLatencyStats[] = [];
+        for (let i = 0; i < n; i++) {
+            const peers = [{
+                nodeName: name((i + 1) % n),
+                targetIPLatencyStats: [{
+                    targetIP: `10.0.0.${i % 255}`,
+                    lastMeasuredRTTNanoseconds: 1_000_000,
+                    lastSendTime: sendTime,
+                    lastRecvTime: recvTime,
+                }],
+            }];
+            if (i === 0) {
+                for (let d = 1; d <= 3; d++) {
+                    peers.push({
+                        nodeName: name(100 + d),
+                        targetIPLatencyStats: [{ targetIP: `10.1.0.${d}`, lastMeasuredRTTNanoseconds: 0, lastSendTime: sendTime, lastRecvTime: recvTime }],
+                    });
+                }
+            }
+            out.push({ metadata: { name: name(i) }, peerNodeLatencyStats: peers });
+        }
+        return out;
+    }
+
+    test('heatmapNodeOrder returns all nodes ranked worst-first', () => {
+        const model = buildModel(makeLargeCluster(300));
+        expect(model.nodes).toHaveLength(300);
+        const order = heatmapNodeOrder(model, false);
+        expect(order).toHaveLength(300);
+        expect(order[0]).toBe('node000');
+    });
+
+    test('heatmapNodeOrder with restrictToProblem returns only problem nodes', () => {
+        const model = buildModel(makeLargeCluster(300));
+        const order = heatmapNodeOrder(model, true);
+        expect(order).toEqual(model.problemNodes.map(p => p.node));
+        expect(order).toContain('node000');
+    });
+});

--- a/client/web/antrea-ui/src/routes/nodelatency-util.ts
+++ b/client/web/antrea-ui/src/routes/nodelatency-util.ts
@@ -1,0 +1,284 @@
+/**
+ * Copyright 2026 Antrea Authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { NodeLatencyStats, TargetIPLatencyStats } from '../api/nodelatency';
+
+// A link is considered "down" when its most recent reply (lastRecvTime) lags the
+// reference time (the newest send across the cluster) by more than this threshold.
+// NodeLatencyMonitor pings every 60s by default, so 3 minutes tolerates a couple of
+// missed probes before flagging a link.
+export const DOWN_STALENESS_MS = 3 * 60 * 1000;
+
+export interface NodeLink {
+    sourceNode: string
+    targetNode: string
+    // Representative RTT in milliseconds (max across target IPs), undefined if unmeasured.
+    rttMs?: number
+    down: boolean
+    targets: TargetIPLatencyStats[]
+}
+
+function parseTime(t: string | undefined): number | undefined {
+    if (!t) return undefined;
+    const ms = Date.parse(t);
+    return isNaN(ms) ? undefined : ms;
+}
+
+// referenceTime is the latest lastSendTime observed across all measurements; using the
+// cluster's own clock avoids false positives from skew between the browser and cluster.
+// Returns the reference time used to determine whether a link is stale.
+// We take the MAX of the cluster's newest lastSendTime and the current browser
+// time. This means:
+//   - When the cluster clock is ahead (skewed), cluster time wins and healthy
+//     links are not falsely flagged as down.
+//   - When the monitor has stopped sending probes entirely, Date.now() advances
+//     while the cluster timestamps stay frozen, so stale links eventually cross
+//     DOWN_STALENESS_MS and are correctly flagged as down.
+export function referenceTime(stats: NodeLatencyStats[]): number {
+    let ref = 0;
+    stats.forEach(stat => stat.peerNodeLatencyStats?.forEach(peer => peer.targetIPLatencyStats?.forEach(t => {
+        const sent = parseTime(t.lastSendTime);
+        if (sent !== undefined && sent > ref) ref = sent;
+    })));
+    return Math.max(ref, Date.now());
+}
+
+export function isTargetDown(target: TargetIPLatencyStats, refTime: number): boolean {
+    if (!target.lastMeasuredRTTNanoseconds || target.lastMeasuredRTTNanoseconds <= 0) return true;
+    const recv = parseTime(target.lastRecvTime);
+    if (recv === undefined) return true;
+    return refTime - recv > DOWN_STALENESS_MS;
+}
+
+export function buildLinks(stats: NodeLatencyStats[], refTime: number = referenceTime(stats)): NodeLink[] {
+    const links: NodeLink[] = [];
+    stats.forEach(stat => {
+        stat.peerNodeLatencyStats?.forEach(peer => {
+            const targets = peer.targetIPLatencyStats ?? [];
+            let maxRttNs: number | undefined;
+            let anyUp = false;
+            targets.forEach(t => {
+                if (t.lastMeasuredRTTNanoseconds !== undefined && t.lastMeasuredRTTNanoseconds > 0 && !isTargetDown(t, refTime)) {
+                    anyUp = true;
+                    if (maxRttNs === undefined || t.lastMeasuredRTTNanoseconds > maxRttNs) maxRttNs = t.lastMeasuredRTTNanoseconds;
+                }
+            });
+            links.push({
+                sourceNode: stat.metadata.name,
+                targetNode: peer.nodeName,
+                rttMs: maxRttNs === undefined ? undefined : maxRttNs / 1e6,
+                down: !anyUp,
+                targets,
+            });
+        });
+    });
+    return links;
+}
+
+export function nodeNames(stats: NodeLatencyStats[]): string[] {
+    const names = new Set<string>();
+    stats.forEach(stat => {
+        names.add(stat.metadata.name);
+        stat.peerNodeLatencyStats?.forEach(peer => names.add(peer.nodeName));
+    });
+    return Array.from(names).sort();
+}
+
+export function mean(values: number[]): number {
+    if (values.length === 0) return NaN;
+    return values.reduce((a, b) => a + b, 0) / values.length;
+}
+
+// Linear-interpolation percentile (p in [0, 100]) over the supplied values.
+export function percentile(values: number[], p: number): number {
+    if (values.length === 0) return NaN;
+    const sorted = [...values].sort((a, b) => a - b);
+    if (sorted.length === 1) return sorted[0];
+    const rank = (p / 100) * (sorted.length - 1);
+    const lo = Math.floor(rank);
+    const hi = Math.ceil(rank);
+    if (lo === hi) return sorted[lo];
+    return sorted[lo] + (sorted[hi] - sorted[lo]) * (rank - lo);
+}
+
+export function median(values: number[]): number {
+    return percentile(values, 50);
+}
+
+export interface AggregatedStats {
+    nodeCount: number
+    measuredCount: number
+    downCount: number
+    meanMs: number
+    medianMs: number
+    p90Ms: number
+    maxMs: number
+}
+
+export function aggregateStats(
+    stats: NodeLatencyStats[],
+    links: NodeLink[] = buildLinks(stats),
+    nodes: string[] = nodeNames(stats),
+): AggregatedStats {
+    const upRtts = links
+        .filter((l): l is NodeLink & { rttMs: number } => !l.down && l.rttMs !== undefined)
+        .map(l => l.rttMs);
+    return {
+        nodeCount: nodes.length,
+        measuredCount: upRtts.length,
+        downCount: links.filter(l => l.down).length,
+        meanMs: mean(upRtts),
+        medianMs: median(upRtts),
+        p90Ms: percentile(upRtts, 90),
+        maxMs: upRtts.reduce((a, b) => a > b ? a : b, NaN),
+    };
+}
+
+// A node is flagged as a "problem" when its number of down ingress or egress links
+// reaches this threshold (i.e. it is failing to reach, or be reached by, multiple peers).
+export const PROBLEM_DOWN_THRESHOLD = 2;
+
+
+export interface NodeHealth {
+    node: string
+    egressDown: number
+    egressTotal: number
+    ingressDown: number
+    ingressTotal: number
+    // Worst up RTT (ms) across all of the node's links, 0 if it has no measured links.
+    maxRttMs: number
+}
+
+export function linkKey(sourceNode: string, targetNode: string): string {
+    return `${sourceNode}|${targetNode}`;
+}
+
+export function nodeHealthMap(links: NodeLink[], nodes: string[]): Map<string, NodeHealth> {
+    const health = new Map<string, NodeHealth>();
+    const ensure = (n: string): NodeHealth => {
+        let h = health.get(n);
+        if (!h) {
+            h = { node: n, egressDown: 0, egressTotal: 0, ingressDown: 0, ingressTotal: 0, maxRttMs: 0 };
+            health.set(n, h);
+        }
+        return h;
+    };
+    nodes.forEach(ensure);
+    links.forEach(l => {
+        const src = ensure(l.sourceNode);
+        const dst = ensure(l.targetNode);
+        src.egressTotal++;
+        dst.ingressTotal++;
+        if (l.down) {
+            src.egressDown++;
+            dst.ingressDown++;
+        } else if (l.rttMs !== undefined) {
+            if (l.rttMs > src.maxRttMs) src.maxRttMs = l.rttMs;
+            if (l.rttMs > dst.maxRttMs) dst.maxRttMs = l.rttMs;
+        }
+    });
+    return health;
+}
+
+function downTotal(h: NodeHealth): number {
+    return h.egressDown + h.ingressDown;
+}
+
+export function problemNodes(health: Map<string, NodeHealth>, threshold: number = PROBLEM_DOWN_THRESHOLD): NodeHealth[] {
+    return Array.from(health.values())
+        .filter(h => h.egressDown >= threshold || h.ingressDown >= threshold)
+        .sort((a, b) => downTotal(b) - downTotal(a) || b.maxRttMs - a.maxRttMs || a.node.localeCompare(b.node));
+}
+
+// rankNodes orders nodes by severity: most down links first, then highest latency, then
+// name. The heatmap uses this so the most interesting nodes survive truncation.
+export function rankNodes(nodes: string[], health: Map<string, NodeHealth>): string[] {
+    return [...nodes].sort((a, b) => {
+        const ha = health.get(a);
+        const hb = health.get(b);
+        const da = ha ? downTotal(ha) : 0;
+        const db = hb ? downTotal(hb) : 0;
+        if (da !== db) return db - da;
+        const ra = ha ? ha.maxRttMs : 0;
+        const rb = hb ? hb.maxRttMs : 0;
+        if (ra !== rb) return rb - ra;
+        return a.localeCompare(b);
+    });
+}
+
+export interface NodeLatencyModel {
+    nodes: string[]
+    links: NodeLink[]
+    linkByKey: Map<string, NodeLink>
+    health: Map<string, NodeHealth>
+    problemNodes: NodeHealth[]
+    problemNodeSet: Set<string>
+    rankedNodes: string[]
+    agg: AggregatedStats
+}
+
+export function filterActiveStats(stats: NodeLatencyStats[], refTime: number = referenceTime(stats)): NodeLatencyStats[] {
+    return stats.filter(stat => {
+        return stat.peerNodeLatencyStats?.some(peer =>
+            peer.targetIPLatencyStats?.some(target => {
+                const sent = parseTime(target.lastSendTime);
+                return sent !== undefined && refTime - sent < DOWN_STALENESS_MS;
+            })
+        );
+    });
+}
+
+export function buildModel(stats: NodeLatencyStats[], threshold: number = PROBLEM_DOWN_THRESHOLD): NodeLatencyModel {
+    const activeStats = filterActiveStats(stats);
+    const refTime = referenceTime(activeStats);
+    const links = buildLinks(activeStats, refTime);
+    const nodes = nodeNames(activeStats);
+    const linkByKey = new Map<string, NodeLink>();
+    links.forEach(l => linkByKey.set(linkKey(l.sourceNode, l.targetNode), l));
+    const health = nodeHealthMap(links, nodes);
+    const problems = problemNodes(health, threshold);
+    return {
+        nodes,
+        links,
+        linkByKey,
+        health,
+        problemNodes: problems,
+        problemNodeSet: new Set(problems.map(p => p.node)),
+        rankedNodes: rankNodes(nodes, health),
+        agg: aggregateStats(activeStats, links, nodes),
+    };
+}
+
+export interface NodeLinks {
+    egress: NodeLink[]
+    ingress: NodeLink[]
+}
+
+// nodeLinksFor returns the links originating from (egress) and terminating at (ingress)
+// the given node. Ingress links are derived by scanning every reporting node's stats.
+export function nodeLinksFor(links: NodeLink[], node: string): NodeLinks {
+    return {
+        egress: links.filter(l => l.sourceNode === node),
+        ingress: links.filter(l => l.targetNode === node),
+    };
+}
+
+export function heatmapNodeOrder(model: NodeLatencyModel, restrictToProblem: boolean): string[] {
+    if (restrictToProblem) {
+        return model.rankedNodes.filter(n => model.problemNodeSet.has(n));
+    }
+    return model.rankedNodes;
+}

--- a/client/web/antrea-ui/src/routes/nodelatency.test.tsx
+++ b/client/web/antrea-ui/src/routes/nodelatency.test.tsx
@@ -1,0 +1,136 @@
+/**
+ * Copyright 2026 Antrea Authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { render, screen, within } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { NodeLatencyStats, nodeLatencyStatsAPI } from '../api/nodelatency';
+import NodeLatency from './nodelatency';
+
+vi.mock('../api/nodelatency');
+const mockedNodeLatencyStatsAPI = vi.mocked(nodeLatencyStatsAPI, true);
+
+// The heatmap renders an ECharts canvas, which jsdom does not implement; stub it so the
+// page-level tests can focus on layout, the stats summary, and the table view.
+vi.mock('./nodelatency-heatmap', () => ({
+    default: () => <div data-testid="heatmap-stub" />,
+}));
+
+afterAll(() => {
+    vi.restoreAllMocks();
+});
+afterEach(() => {
+    vi.clearAllMocks();
+});
+
+const sendTime = () => new Date(Date.now()).toISOString();
+const recvTime = () => new Date(Date.now()).toISOString();
+
+const stats: NodeLatencyStats[] = [
+    {
+        metadata: { name: 'kind-worker' },
+        peerNodeLatencyStats: [
+            {
+                nodeName: 'kind-control-plane',
+                targetIPLatencyStats: [
+                    {
+                        targetIP: '10.10.0.1',
+                        lastMeasuredRTTNanoseconds: 5837000,
+                        lastSendTime: sendTime(),
+                        lastRecvTime: recvTime(),
+                    },
+                ],
+            },
+        ],
+    },
+];
+
+// node-a fails to reach two peers (2 down egress links) so it is a problem node.
+const problemStats: NodeLatencyStats[] = [
+    {
+        metadata: { name: 'node-a' },
+        peerNodeLatencyStats: [
+            { nodeName: 'node-b', targetIPLatencyStats: [{ targetIP: '10.0.0.2', lastSendTime: sendTime() }] },
+            { nodeName: 'node-c', targetIPLatencyStats: [{ targetIP: '10.0.0.3', lastSendTime: sendTime() }] },
+            {
+                nodeName: 'node-d',
+                targetIPLatencyStats: [{ targetIP: '10.0.0.4', lastMeasuredRTTNanoseconds: 3_000_000, lastSendTime: sendTime(), lastRecvTime: recvTime() }],
+            },
+        ],
+    },
+];
+
+describe('NodeLatency', () => {
+    test('shows the stats summary and the heatmap by default', async () => {
+        mockedNodeLatencyStatsAPI.fetchAll.mockResolvedValueOnce(stats);
+        render(<NodeLatency />);
+        expect(await screen.findByTestId('heatmap-stub')).toBeInTheDocument();
+        expect(screen.getByText('Measured Links')).toBeInTheDocument();
+        expect(mockedNodeLatencyStatsAPI.fetchAll).toHaveBeenCalledTimes(1);
+    });
+
+    test('table view renders a row per target IP measurement', async () => {
+        mockedNodeLatencyStatsAPI.fetchAll.mockResolvedValueOnce(stats);
+        render(<NodeLatency />);
+        await userEvent.click(await screen.findByRole('button', { name: 'Table' }));
+        const row = await screen.findByRole('row', {
+            name: new RegExp('kind-worker kind-control-plane 10\\.10\\.0\\.1 5\\.837'),
+        });
+        expect(within(row).getByRole('cell', { name: '5.837' })).toBeInTheDocument();
+    });
+
+    test('shows empty state when no measurements are available', async () => {
+        mockedNodeLatencyStatsAPI.fetchAll.mockResolvedValueOnce([]);
+        render(<NodeLatency />);
+        expect(await screen.findByText(/No Node latency measurements are available/i)).toBeInTheDocument();
+        expect(screen.queryByRole('button', { name: 'Table' })).not.toBeInTheDocument();
+    });
+
+    test('searching a node opens its detail panel', async () => {
+        mockedNodeLatencyStatsAPI.fetchAll.mockResolvedValueOnce(problemStats);
+        render(<NodeLatency />);
+        const input = await screen.findByLabelText('Search Node');
+        await userEvent.type(input, 'node-a');
+        expect(await screen.findByText('Node: node-a')).toBeInTheDocument();
+        expect(screen.getByText('Egress Links')).toBeInTheDocument();
+        expect(screen.getByText('Ingress Links')).toBeInTheDocument();
+    });
+
+    test('lists problem nodes and inspecting one opens its detail panel', async () => {
+        mockedNodeLatencyStatsAPI.fetchAll.mockResolvedValueOnce(problemStats);
+        render(<NodeLatency />);
+        expect(await screen.findByText('Problem Nodes (1)')).toBeInTheDocument();
+        await userEvent.click(screen.getByRole('button', { name: 'Inspect' }));
+        expect(await screen.findByText('Node: node-a')).toBeInTheDocument();
+    });
+
+    test('table view renders N/A for a missing RTT', async () => {
+        mockedNodeLatencyStatsAPI.fetchAll.mockResolvedValueOnce([
+            {
+                metadata: { name: 'kind-worker' },
+                peerNodeLatencyStats: [
+                    {
+                        nodeName: 'kind-worker2',
+                        targetIPLatencyStats: [{ targetIP: '10.10.2.1' }],
+                    },
+                ],
+            },
+        ]);
+        render(<NodeLatency />);
+        await userEvent.click(await screen.findByRole('button', { name: 'Table' }));
+        const row = await screen.findByRole('row', { name: /kind-worker2 10\.10\.2\.1 N\/A/ });
+        expect(within(row).getByRole('cell', { name: 'N/A' })).toBeInTheDocument();
+    });
+});

--- a/client/web/antrea-ui/src/routes/nodelatency.tsx
+++ b/client/web/antrea-ui/src/routes/nodelatency.tsx
@@ -1,0 +1,235 @@
+/**
+ * Copyright 2026 Antrea Authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { useState, useEffect, useMemo } from 'react';
+import { CdsCard } from '@cds/react/card';
+import { CdsButton } from '@cds/react/button';
+import { CdsInput } from '@cds/react/input';
+import { CdsCheckbox } from '@cds/react/checkbox';
+import { CdsDivider } from '@cds/react/divider';
+import { NodeLatencyStats, nodeLatencyStatsAPI } from '../api/nodelatency';
+import { useAppError } from '../components/errors';
+import { WaitForAPIResource } from '../components/progress';
+import NodeLatencyStatsSummary from '../components/nodelatency-stats';
+import { NodeDetailPanel, ProblemNodesPanel } from '../components/nodelatency-detail';
+import NodeLatencyHeatmap from './nodelatency-heatmap';
+import { buildModel } from './nodelatency-util';
+
+type ViewMode = 'heatmap' | 'table';
+
+const REFRESH_INTERVAL_MS = 15 * 1000;
+
+// Cap rows rendered in the flat table so a full mesh on a large cluster (up to N*N rows)
+// cannot freeze the page; the heatmap and per-node detail panel cover the full data set.
+const MAX_TABLE_ROWS = 500;
+
+const latencyProperties = ['Source Node', 'Target Node', 'Target IP', 'Latency (ms)', 'Last Send', 'Last Recv'];
+
+interface LatencyRow {
+    sourceNode: string
+    targetNode: string
+    targetIP: string
+    latencyMs: string
+    lastSend: string
+    lastRecv: string
+}
+
+function formatRTT(rttNanoseconds: number | undefined): string {
+    if (rttNanoseconds === undefined || rttNanoseconds <= 0) return 'N/A';
+    return (rttNanoseconds / 1e6).toFixed(3);
+}
+
+function formatTime(t: string | undefined): string {
+    if (!t) return 'None';
+    return new Date(t).toLocaleString();
+}
+
+function flattenStats(stats: NodeLatencyStats[]): LatencyRow[] {
+    const rows: LatencyRow[] = [];
+    stats.forEach(stat => {
+        stat.peerNodeLatencyStats?.forEach(peer => {
+            peer.targetIPLatencyStats?.forEach(target => {
+                rows.push({
+                    sourceNode: stat.metadata.name,
+                    targetNode: peer.nodeName,
+                    targetIP: target.targetIP,
+                    latencyMs: formatRTT(target.lastMeasuredRTTNanoseconds),
+                    lastSend: formatTime(target.lastSendTime),
+                    lastRecv: formatTime(target.lastRecvTime),
+                });
+            });
+        });
+    });
+    return rows;
+}
+
+function LatencyTable(props: { rows: LatencyRow[] }) {
+    if (props.rows.length === 0) {
+        return (
+            <CdsCard>
+                <div cds-layout="vertical gap:md p:md">
+                    <p>No Node latency measurements are available.</p>
+                    <p cds-text="secondary">
+                        Ensure the Antrea <code>NodeLatencyMonitor</code> feature gate is enabled and a
+                        NodeLatencyMonitor resource is configured. Measurements may take a moment to appear.
+                    </p>
+                </div>
+            </CdsCard>
+        );
+    }
+    const shown = props.rows.slice(0, MAX_TABLE_ROWS);
+    return (
+        <CdsCard>
+            <div cds-layout="vertical gap:md">
+                {props.rows.length > shown.length && (
+                    <p cds-text="secondary">
+                        Showing the first {shown.length} of {props.rows.length} measurements. Use the
+                        heatmap or search a node to inspect the rest.
+                    </p>
+                )}
+                <table cds-table="border:all" cds-text="center body">
+                    <thead>
+                        <tr>
+                            {latencyProperties.map(name => (
+                                <th key={name}>{name}</th>
+                            ))}
+                        </tr>
+                    </thead>
+                    <tbody>
+                        {shown.map((row, idx) => (
+                            <tr key={idx}>
+                                <td>{row.sourceNode}</td>
+                                <td>{row.targetNode}</td>
+                                <td>{row.targetIP}</td>
+                                <td>{row.latencyMs}</td>
+                                <td>{row.lastSend}</td>
+                                <td>{row.lastRecv}</td>
+                            </tr>
+                        ))}
+                    </tbody>
+                </table>
+            </div>
+        </CdsCard>
+    );
+}
+
+export default function NodeLatency() {
+    const [stats, setStats] = useState<NodeLatencyStats[]>();
+    const [viewMode, setViewMode] = useState<ViewMode>('heatmap');
+    const [selected, setSelected] = useState('');
+    const [problemOnly, setProblemOnly] = useState(false);
+    const { addError, removeError } = useAppError();
+
+    useEffect(() => {
+        let cancelled = false;
+
+        async function getData() {
+            try {
+                const stats = await nodeLatencyStatsAPI.fetchAll();
+                if (cancelled) return;
+                setStats(stats);
+                removeError();
+            } catch (e) {
+                if (e instanceof Error) addError(e);
+                console.error(e);
+            }
+        }
+
+        getData();
+        const timer = setInterval(getData, REFRESH_INTERVAL_MS);
+        return () => {
+            cancelled = true;
+            clearInterval(timer);
+        };
+    }, [addError, removeError]);
+
+    const model = useMemo(() => buildModel(stats ?? []), [stats]);
+    const rows = useMemo(() => flattenStats(stats ?? []), [stats]);
+    const selectedNode = model.nodes.includes(selected) ? selected : '';
+
+    return (
+        <main>
+            <div cds-layout="vertical gap:lg">
+                <p cds-text="title">Node Latency</p>
+                <CdsDivider></CdsDivider>
+                <WaitForAPIResource ready={stats !== undefined} text="Loading Node Latency Stats">
+                    {rows.length === 0 ? (
+                        <LatencyTable rows={rows} />
+                    ) : (
+                        <div cds-layout="vertical gap:lg">
+                            <NodeLatencyStatsSummary agg={model.agg} />
+
+                            <CdsInput>
+                                <label>Search Node</label>
+                                <input
+                                    type="text"
+                                    list="nl-node-options"
+                                    placeholder="Node name"
+                                    value={selected}
+                                    onChange={e => setSelected(e.target.value)}
+                                />
+                            </CdsInput>
+                            <datalist id="nl-node-options">
+                                {model.nodes.map(n => <option key={n} value={n} />)}
+                            </datalist>
+
+                            {selectedNode && (
+                                <NodeDetailPanel model={model} node={selectedNode} onClose={() => setSelected('')} />
+                            )}
+
+                            <ProblemNodesPanel model={model} onSelect={setSelected} />
+
+                            <div cds-layout="horizontal gap:md align:vertical-center">
+                                <div cds-layout="horizontal gap:xs">
+                                    <CdsButton
+                                        type="button"
+                                        action={viewMode === 'heatmap' ? 'solid' : 'outline'}
+                                        size="sm"
+                                        onClick={() => setViewMode('heatmap')}
+                                    >
+                                        Heatmap
+                                    </CdsButton>
+                                    <CdsButton
+                                        type="button"
+                                        action={viewMode === 'table' ? 'solid' : 'outline'}
+                                        size="sm"
+                                        onClick={() => setViewMode('table')}
+                                    >
+                                        Table
+                                    </CdsButton>
+                                </div>
+                                {viewMode === 'heatmap' && model.problemNodes.length > 0 && (
+                                    <CdsCheckbox>
+                                        <label>Problem nodes only</label>
+                                        <input
+                                            type="checkbox"
+                                            checked={problemOnly}
+                                            onChange={e => setProblemOnly(e.target.checked)}
+                                        />
+                                    </CdsCheckbox>
+                                )}
+                            </div>
+
+                            {viewMode === 'heatmap'
+                                ? <NodeLatencyHeatmap model={model} restrictToProblem={problemOnly} />
+                                : <LatencyTable rows={rows} />}
+                        </div>
+                    )}
+                </WaitForAPIResource>
+            </div>
+        </main>
+    );
+}

--- a/docs/node-latency.md
+++ b/docs/node-latency.md
@@ -1,0 +1,48 @@
+# Node Latency Dashboard
+
+The **Node Latency** dashboard visualizes the inter-Node round-trip latency
+measurements reported by Antrea's
+[NodeLatencyMonitor](https://antrea.io/docs/main/docs/features/node-latency-monitor/)
+feature. It reads the cluster-scoped `NodeLatencyStats` resources from the
+`stats.antrea.io/v1alpha1` API (the same data returned by
+`kubectl get nodelatencystats`).
+
+## Prerequisites
+
+The `NodeLatencyMonitor` feature gate must be enabled in the Antrea Agent, and a
+`NodeLatencyMonitor` resource must be configured to start measurements. If no
+measurements are available, the dashboard shows an empty state with these
+instructions. No additional `antrea-ui` configuration is required; the data is
+fetched through the existing Kubernetes API proxy.
+
+## Views
+
+- **Summary cards**: aggregate statistics over all measured links — node count,
+  measured links, down links, and mean / median / P90 / max latency (ms).
+- **Heatmap** (default): a ping-mesh matrix with source Nodes on the Y axis and
+  target Nodes on the X axis, colored from green (low RTT) to red (high RTT).
+  Down links are gray. Problem-node axis labels are colored red.
+- **Table**: a flat list of every measurement (source, target, target IP, RTT,
+  last send / receive times).
+- **Search**: select a Node by name to open a detail panel listing all of its
+  egress links (this Node → peers) and ingress links (peers → this Node), each
+  with status, RTT, target IPs, and last receive time.
+- **Problem Nodes**: lists Nodes with multiple down ingress or egress links.
+
+## How a link is classified as "down"
+
+A measurement (one target IP of one peer) is considered **down** when either:
+
+- it has no measured RTT (`lastMeasuredRTTNanoseconds` is absent or zero), or
+- its `lastRecvTime` lags the reference time by more than 3 minutes
+  (`DOWN_STALENESS_MS`), i.e. no probe reply has been received recently.
+
+The reference time is the newest `lastSendTime` observed across the whole cluster
+rather than the browser clock, to avoid false positives from clock skew between
+the browser and the cluster. A source→target link is down only when all of its
+target IPs are down. A Node is flagged as a problem when it has 2 or more down
+ingress or egress links (`PROBLEM_DOWN_THRESHOLD`).
+
+## Large clusters
+
+Better handling possible? Need reviews. 

--- a/pkg/server/api/k8s.go
+++ b/pkg/server/api/k8s.go
@@ -28,6 +28,7 @@ import (
 var allowedK8sPaths = []string{
 	"/apis/crd.antrea.io/v1beta1/antreaagentinfos",
 	"/apis/crd.antrea.io/v1beta1/antreacontrollerinfos",
+	"/apis/stats.antrea.io/v1alpha1/nodelatencystats",
 }
 
 func (s *Server) GetK8s(c *gin.Context) {

--- a/pkg/server/api/k8s_test.go
+++ b/pkg/server/api/k8s_test.go
@@ -43,6 +43,11 @@ func TestK8sProxyRequest(t *testing.T) {
 			expectedStatusCode: http.StatusOK,
 		},
 		{
+			name:               "allowed path 3",
+			path:               "/apis/stats.antrea.io/v1alpha1/nodelatencystats",
+			expectedStatusCode: http.StatusOK,
+		},
+		{
 			name:               "forbidden path",
 			path:               "/api/v1/pods",
 			expectedStatusCode: http.StatusNotFound,


### PR DESCRIPTION
Adding code for a dedicated dashboard. It's not fully complete, it needs reviews and many changes. 

<img width="1907" height="1035" alt="image" src="https://github.com/user-attachments/assets/c76f45c8-969a-463f-9be6-e16c487166b8" />


As of now, it looks as such as I've mentioned in the https://github.com/antrea-io/antrea-ui/issues/455#issuecomment-4798062366 too 