### PR TITLE
Group react and react-dom updates in Renovate

### DIFF
--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -51,6 +51,14 @@
       enabled: false,
     },
 
+    // Keep react and react-dom in sync, since they must have the exact same version
+    {
+      matchManagers: ["npm"],
+      matchPackageNames: ["react", "react-dom"],
+      groupName: "react",
+      groupSlug: "react",
+    },
+
     // Disable indirect go dependencies updates, resource: https://github.com/renovatebot/renovate/discussions/35225#discussioncomment-13666269
     {
       matchManagers: ["gomod"],


### PR DESCRIPTION
PR #1300 broke CI because Renovate bumped react to 19.2.7 while leaving react-dom at 19.2.5, and React requires both packages to have the exact same version. Add a packageRule that groups react and react-dom so Renovate always updates them together in a single PR.