### PR TITLE
Increase HTTP retry budget for TestInstall/https_-_auto

### DIFF
--- a/test/e2e_helm/install_test.go
+++ b/test/e2e_helm/install_test.go
@@ -54,7 +54,7 @@ func checkAPIAccess(scheme string, tlsConfig *tls.Config) func(t *testing.T, end
 			t,
 			url.String(),
 			tlsConfig,
-			10,            // retries
+			30,            // retries
 			1*time.Second, // sleep between retries
 			func(statusCode int, body string) bool {
 				return statusCode == 200


### PR DESCRIPTION
The "https - auto" case in the e2e_helm install test connects to the Antrea UI pod over HTTPS shortly after the Deployment reports Available, but the pod intermittently isn't yet accepting connections on port 3000 at that point. With only 10 retries at 1s intervals, the 10s budget is sometimes too tight and the test fails with connection refused/EOF errors, even though the pod becomes reachable shortly after. The plain HTTP subtests are not affected and consistently pass within a few seconds.

Raise the retry count from 10 to 30 to give the pod more time to become reachable and reduce this CI flakiness.