### PR TITLE
fix(deps): update antrea-ui-components to typescript v6

### DIFF
--- a/client/web/antrea-ui-components/package.json
+++ b/client/web/antrea-ui-components/package.json
@@ -33,7 +33,7 @@
     "eslint": "^9.31.0",
     "globals": "^17.0.0",
     "jsdom": "^29.0.0",
-    "typescript": "^5.0.0",
+    "typescript": "^6.0.0",
     "typescript-eslint": "^8.36.0",
     "vite": "^8.0.0",
     "vitest": "^4.0.5"

--- a/client/web/antrea-ui-components/tsconfig.json
+++ b/client/web/antrea-ui-components/tsconfig.json
@@ -7,6 +7,7 @@
     "declaration": true,
     "declarationDir": "dist",
     "outDir": "dist",
+    "rootDir": "src",
     "strict": true,
     "experimentalDecorators": true,
     "useDefineForClassFields": false,

--- a/client/web/yarn.lock
+++ b/client/web/yarn.lock
@@ -27,7 +27,7 @@ __metadata:
     is-ip: "npm:^5.0.1"
     jsdom: "npm:^29.0.0"
     lit: "npm:^3.0.0"
-    typescript: "npm:^5.0.0"
+    typescript: "npm:^6.0.0"
     typescript-eslint: "npm:^8.36.0"
     vite: "npm:^8.0.0"
     vitest: "npm:^4.0.5"
@@ -5443,16 +5443,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"typescript@npm:^5.0.0":
-  version: 5.9.3
-  resolution: "typescript@npm:5.9.3"
-  bin:
-    tsc: bin/tsc
-    tsserver: bin/tsserver
-  checksum: 10c0/6bd7552ce39f97e711db5aa048f6f9995b53f1c52f7d8667c1abdc1700c68a76a308f579cd309ce6b53646deb4e9a1be7c813a93baaf0a28ccd536a30270e1c5
-  languageName: node
-  linkType: hard
-
 "typescript@npm:^6.0.0":
   version: 6.0.3
   resolution: "typescript@npm:6.0.3"
@@ -5460,16 +5450,6 @@ __metadata:
     tsc: bin/tsc
     tsserver: bin/tsserver
   checksum: 10c0/4a25ff5045b984370f48f196b3a0120779b1b343d40b9a68d114ea5e5fff099809b2bb777576991a63a5cd59cf7bffd96ff6fe10afcefbcb8bd6fb96ad4b6606
-  languageName: node
-  linkType: hard
-
-"typescript@patch:typescript@npm%3A^5.0.0#optional!builtin<compat/typescript>":
-  version: 5.9.3
-  resolution: "typescript@patch:typescript@npm%3A5.9.3#optional!builtin<compat/typescript>::version=5.9.3&hash=5786d5"
-  bin:
-    tsc: bin/tsc
-    tsserver: bin/tsserver
-  checksum: 10c0/ad09fdf7a756814dce65bc60c1657b40d44451346858eea230e10f2e95a289d9183b6e32e5c11e95acc0ccc214b4f36289dcad4bf1886b0adb84d711d336a430
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
## Summary
- Bumps `@antrea/ui-components`'s `typescript` from `^5.0.0` to `^6.0.0`, aligning it with `antrea-ui` (already on `^6.0.0`) so the workspace resolves a single TypeScript version.
- Adds `rootDir: "src"` to `antrea-ui-components/tsconfig.json`: TypeScript 6 requires this to be set explicitly when `declarationDir`/`outDir` are configured (`TS5011`).

Replaces #1295, which bumped both packages straight to `typescript@^7.0.0`. TypeScript v7 (the native/Corsa rewrite) currently exposes no classic compiler API, so `typescript-eslint` crashes on it with `TypeError: Cannot read properties of undefined (reading 'Cjs')` — a known, unresolved incompatibility ([typescript-eslint#12518](https://github.com/typescript-eslint/typescript-eslint/issues/12518)). That upgrade should wait until `typescript-eslint` ships v7 support.

## Test plan
- [x] `yarn workspace antrea-ui run build`
- [x] `yarn workspace antrea-ui run lint`
- [x] `yarn workspace antrea-ui run test run`
- [x] `yarn workspace @antrea/ui-components run build`
- [x] `yarn workspace @antrea/ui-components run lint`
- [x] `yarn workspace @antrea/ui-components run test run`