### PR TITLE
fix: avoid data race in newTestServer plugin registry goroutine

### DIFF
--- a/pkg/server/api/server_test.go
+++ b/pkg/server/api/server_test.go
@@ -19,6 +19,7 @@ import (
 	"net/http"
 	"net/http/httptest"
 	"net/http/httputil"
+	"sync"
 	"testing"
 
 	"github.com/gin-gonic/gin"
@@ -93,8 +94,16 @@ func newTestServer(t *testing.T, options ...testServerOptions) *testServer {
 	pluginsClientset := k8sfake.NewSimpleClientset()
 	pluginRegistry := plugins.NewRegistry(logger, pluginsClientset, "antrea-ui", "ui.antrea.io/plugin=true")
 	stopCh := make(chan struct{})
-	t.Cleanup(func() { close(stopCh) })
-	go pluginRegistry.Run(stopCh)
+	var wg sync.WaitGroup
+	wg.Add(1)
+	go func() {
+		defer wg.Done()
+		pluginRegistry.Run(stopCh)
+	}()
+	t.Cleanup(func() {
+		close(stopCh)
+		wg.Wait()
+	})
 
 	s := NewServer(
 		logger,


### PR DESCRIPTION
Cleanup only closed stopCh without waiting for the Registry.Run
goroutine to exit, so its testr-backed logging could race with the
test being marked done. Wait on a WaitGroup after closing stopCh.

Signed-off-by: Anlan He <anlan.he@broadcom.com>

