### PR TITLE
Export APIError from antrea-ui-components

### DIFF
--- a/client/web/antrea-ui-components/src/index.ts
+++ b/client/web/antrea-ui-components/src/index.ts
@@ -26,4 +26,4 @@ export type { FlowEntry } from './lib/flow-store.js';
 export { AntreaLoginPage } from './pages/antrea-login-page.js';
 export type { AppSettings, Token } from './lib/auth-api.js';
 export { apiLogin, apiRefreshToken, apiFetchAppSettings } from './lib/auth-api.js';
-export { setApiBase, getApiBase } from './lib/api.js';
+export { APIError, setApiBase, getApiBase } from './lib/api.js';


### PR DESCRIPTION
APIError already existed in lib/api.ts but wasn't re-exported from
index.ts, so consumers outside the package couldn't reference it.

Signed-off-by: Anlan He <anlan.he@broadcom.com>