### PR TITLE
Allow proxying NetworkPolicy resources through the K8s API

### DIFF
--- a/pkg/server/api/k8s.go
+++ b/pkg/server/api/k8s.go
@@ -34,8 +34,8 @@ import (
 // ClusterRole grants is exactly what's reachable through this proxy - the same permissions an
 // admin already approved by applying that RBAC in the first place.
 var allowedK8sPaths = []string{
-	"/apis/crd.antrea.io/v1beta1/antreaagentinfos",
-	"/apis/crd.antrea.io/v1beta1/antreacontrollerinfos",
+	"/apis/crd.antrea.io/",
+	"/apis/networking.k8s.io/v1",
 	"/api/v1/",
 }
 

--- a/pkg/server/api/k8s_test.go
+++ b/pkg/server/api/k8s_test.go
@@ -48,6 +48,21 @@ func TestK8sProxyRequest(t *testing.T) {
 			expectedStatusCode: http.StatusOK,
 		},
 		{
+			name:               "allowed path 4",
+			path:               "/apis/networking.k8s.io/v1/networkpolicies",
+			expectedStatusCode: http.StatusOK,
+		},
+		{
+			name:               "allowed path 5",
+			path:               "/apis/crd.antrea.io/v1beta1/networkpolicies",
+			expectedStatusCode: http.StatusOK,
+		},
+		{
+			name:               "allowed path 6",
+			path:               "/apis/crd.antrea.io/v1beta1/clusternetworkpolicies",
+			expectedStatusCode: http.StatusOK,
+		},
+		{
 			name:               "forbidden path",
 			path:               "/apis/apps/v1/deployments",
 			expectedStatusCode: http.StatusNotFound,


### PR DESCRIPTION
Adds networking.k8s.io NetworkPolicy and Antrea NetworkPolicy / ClusterNetworkPolicy to allowedK8sPaths so a page or plugin can read policy state through the existing /api/v1/k8s/<path> proxy — needed by the Policy Management example plugin's Policy Definitions view.