### PR TITLE
Wait for helm delete in e2e_helm TestInstall subtests

### DIFF
--- a/test/e2e_helm/install_test.go
+++ b/test/e2e_helm/install_test.go
@@ -131,6 +131,15 @@ stringData:
 			helmOptions := &helm.Options{
 				KubectlOptions: kubectlOptions,
 				SetValues:      tc.helmSetValues,
+				// the chart's resource names (e.g., the antrea-ui Deployment and Service) are
+				// not templated with the release name, so they are shared across subtests. Without
+				// --wait, "helm delete" returns as soon as the deletion is submitted to the API
+				// server, before the old Pod actually terminates. The next subtest's Service can
+				// then briefly select the old (Terminating) Pod instead of the new one, causing
+				// connection failures that no amount of HTTP retries can fix.
+				ExtraArgs: map[string][]string{
+					"delete": {"--wait"},
+				},
 			}
 
 			// Run pre-install setup if provided


### PR DESCRIPTION
The antrea-ui chart's Deployment and Service names are fixed and not templated with the release name, so all TestInstall subtests share the same resources in the kube-system namespace. helm delete returns as soon as deletion is submitted to the API server, before the old Pod actually terminates. This let the next subtest's port-forward race against the still-terminating Pod from the previous subtest and select it instead of the freshly installed one, causing spurious connection failures (e.g. `TestInstall/https_-_auto`) that increasing the HTTP retry budget in 3782fb41a8c7 could not actually fix, since the selected Pod would never come up.

Pass --wait to helm delete so the old release's Pod is fully gone before the next subtest installs.