### PR TITLE
Add optional route and federation fields to PluginManifest

### DIFF
--- a/apis/v1/plugins.go
+++ b/apis/v1/plugins.go
@@ -30,16 +30,27 @@ package v1
 type PluginManifest struct {
 	Name    string `json:"name"`
 	Version string `json:"version"`
-	Entry   string `json:"entry"`
+	// Entry is always eagerly import()-ed by the host at startup, for
+	// whatever page-extension registration the plugin's code performs via
+	// antrea-ui-plugin-sdk (registerEdgeExtraRenderer() etc) - regardless of
+	// whether Route/Federation below are also present. A plugin with
+	// nothing to register eagerly still needs a (possibly no-op) Entry: it
+	// remains required.
+	Entry string `json:"entry"`
 
 	// Route optionally declares a whole-page route/sidebar entry for this
 	// plugin as data the host can act on immediately, instead of waiting for
 	// the plugin's own code to call registerRoute()/registerSidebarEntry()
-	// (see antrea-ui-plugin-sdk) as a side effect of loading it. Chiefly
-	// useful paired with Federation (see below), where the point of the
-	// exercise is to defer fetching/running the plugin's page code until its
-	// route is actually visited - which requires the host to already know
-	// the route before that happens.
+	// (see antrea-ui-plugin-sdk) as a side effect of loading it. Currently
+	// only meaningful paired with Federation (required whenever Route is
+	// set - see parsePluginConfigMap): Federation.ExposedModule is what the
+	// host actually mounts at Route.Path. A plain custom-element plugin has
+	// no equivalent here (there's no "Tag" field, unlike the SDK's
+	// PluginRoute) because registering such a route via code is already
+	// cheap - the data-only path exists specifically to defer loading a
+	// route's code, which only pays for itself when there's a nontrivial
+	// federated bundle behind it. Nothing prevents adding a lighter,
+	// Federation-less variant later if a use case for it shows up.
 	Route *PluginRoute `json:"route,omitempty"`
 
 	// Federation optionally declares a module federation remote (e.g. a

--- a/apis/v1/plugins.go
+++ b/apis/v1/plugins.go
@@ -18,9 +18,15 @@ package v1
 // labeled ConfigMap. It carries just enough for the host to fetch and
 // import() the right file. Page extensions (e.g. edge details, flow table
 // columns) are always registered by the plugin's own code, since the host
-// needs an actual function reference for those; a whole-page route is the
-// one exception - Route lets the host build it from data alone, without
-// running any of the plugin's code first (see Route's own doc).
+// needs an actual function reference for those - Entry is always eagerly
+// imported for that purpose alone, whether or not Route/Federation are also
+// present. A whole-page route is the one exception - Route lets the host
+// build it from data alone, without running any of the plugin's code first
+// (see Route's own doc). A plugin can do both at once (e.g. an eager Entry
+// that only registers a page-extension renderer, plus a Route/Federation
+// pair describing an unrelated, separately-built, lazily-loaded page) -
+// Federation.RemoteEntry is deliberately its own file, not Entry, so the two
+// concerns never have to share one build artifact.
 type PluginManifest struct {
 	Name    string `json:"name"`
 	Version string `json:"version"`
@@ -30,18 +36,19 @@ type PluginManifest struct {
 	// plugin as data the host can act on immediately, instead of waiting for
 	// the plugin's own code to call registerRoute()/registerSidebarEntry()
 	// (see antrea-ui-plugin-sdk) as a side effect of loading it. Chiefly
-	// useful for a plugin loaded via module federation (see Federation),
-	// where the point of the exercise is to defer fetching/running the
-	// plugin's code until its route is actually visited - which requires the
-	// host to already know the route before that happens.
+	// useful paired with Federation (see below), where the point of the
+	// exercise is to defer fetching/running the plugin's page code until its
+	// route is actually visited - which requires the host to already know
+	// the route before that happens.
 	Route *PluginRoute `json:"route,omitempty"`
 
-	// Federation optionally declares that Entry is a module federation
-	// remote entry (e.g. a Native Federation "remoteEntry.json"), rather
-	// than a module the host can plainly import(). A host that understands
-	// this field loads ExposedModule out of it via its federation runtime
-	// instead; a host that doesn't (or a plugin that omits this field
-	// entirely) keeps using Entry as a plain ES module, unaffected.
+	// Federation optionally declares a module federation remote (e.g. a
+	// Native Federation "remoteEntry.json") the host can lazily load a
+	// component out of - normally paired with Route, to render at that
+	// route. Deliberately a file of its own rather than reusing Entry: Entry
+	// stays reserved for whatever a plugin needs eagerly loaded (page
+	// extensions), which may have nothing to do with, and may be far
+	// cheaper than, a lazily-loaded federated page.
 	Federation *PluginFederation `json:"federation,omitempty"`
 }
 
@@ -57,11 +64,14 @@ type PluginRoute struct {
 	Icon string `json:"icon,omitempty"`
 }
 
-// PluginFederation carries the one extra piece of information a federation
-// runtime needs beyond a remote entry URL: which of that remote's exposed
-// modules to load. Shared-dependency negotiation is otherwise handled
-// entirely by the remote entry file itself (e.g. by the plugin's own
-// federation.config.js at build time), so nothing else belongs here.
+// PluginFederation carries the two things a federation runtime needs beyond
+// what Entry already provides: its own remote entry file (see
+// PluginManifest's doc for why this isn't just Entry), and which of that
+// remote's exposed modules to load. Shared-dependency negotiation is
+// otherwise handled entirely by the remote entry file itself (e.g. by the
+// plugin's own federation.config.js at build time), so nothing else belongs
+// here.
 type PluginFederation struct {
+	RemoteEntry   string `json:"remoteEntry"`
 	ExposedModule string `json:"exposedModule"`
 }

--- a/apis/v1/plugins.go
+++ b/apis/v1/plugins.go
@@ -17,50 +17,46 @@ package v1
 // PluginManifest describes a frontend plugin discovered by the backend from a
 // labeled ConfigMap. Page extensions (edge details, flow table columns) are
 // always registered by the plugin's own code - the host needs an actual
-// function reference for those. Routes is the one exception: it lets the
-// host build a whole-page route from data alone, without running the
-// plugin's code first.
+// function reference for those. Federation is the one exception: it lets the
+// host build whole-page routes from data alone, without running the plugin's
+// code first.
 type PluginManifest struct {
 	Name    string `json:"name"`
 	Version string `json:"version"`
 	// Entry is the plugin's entry file: a filename, a key in the same
 	// ConfigMap's data. Always eagerly import()-ed at startup, for whatever
 	// page-extension registration the plugin's code performs (see
-	// antrea-ui-plugin-sdk) - regardless of whether Routes/Federation below
-	// are also set.
+	// antrea-ui-plugin-sdk) - regardless of whether Federation below is also
+	// set.
 	Entry string `json:"entry"`
 
-	// Routes optionally declares whole-page routes as data, instead of the
-	// plugin's code calling registerRoute()/registerSidebarEntry() (see
-	// antrea-ui-plugin-sdk). A list because registerRoute() isn't limited to
-	// one call either. Requires Federation: each entry's ExposedModule is
-	// what the host actually mounts at its Path, and nothing else can supply
-	// that yet - a plain custom-element route is already cheap via code, so
-	// there's nothing here worth deferring for it.
-	Routes []PluginRoute `json:"routes,omitempty"`
-
-	// Federation optionally declares the plugin's module federation remote -
-	// its own file, not Entry, so an eager page extension and a lazily-loaded
+	// Federation optionally declares the plugin's module federation remote
+	// and the routes it serves, as data instead of the plugin's code calling
+	// registerRoute()/registerSidebarEntry() (see antrea-ui-plugin-sdk). Its
+	// own file, not Entry, so an eager page extension and a lazily-loaded
 	// federated page never have to share one build artifact.
 	Federation *PluginFederation `json:"federation,omitempty"`
 }
 
+// PluginFederation is the plugin's federation remote entry file, plus the
+// routes to load components from it for. A route's ExposedModule is what the
+// host actually mounts at its Path - there's no equivalent for a plain
+// custom-element route, since that's already cheap via code, with nothing
+// here worth deferring for it.
+type PluginFederation struct {
+	RemoteEntry string        `json:"remoteEntry"`
+	Routes      []PluginRoute `json:"routes"`
+}
+
 // PluginRoute mirrors registerRoute()/registerSidebarEntry()'s
-// antrea-ui-plugin-sdk info, as data.
+// antrea-ui-plugin-sdk info, as data, plus which component to mount.
 type PluginRoute struct {
 	Path         string `json:"path"`
 	SidebarLabel string `json:"sidebarLabel"`
 	// Icon is optional SVG path "d" data, 16x16 viewBox "0 0 16 16", matching
 	// PluginSidebarEntry.icon in antrea-ui-plugin-sdk.
 	Icon string `json:"icon,omitempty"`
-	// ExposedModule names which component Federation.RemoteEntry exposes for
-	// this route.
+	// ExposedModule names which component the enclosing PluginFederation's
+	// RemoteEntry exposes for this route.
 	ExposedModule string `json:"exposedModule"`
-}
-
-// PluginFederation is the plugin's federation remote entry file. Which
-// component to load from it is per-route (PluginRoute.ExposedModule), since
-// one remote can expose components for more than one route.
-type PluginFederation struct {
-	RemoteEntry string `json:"remoteEntry"`
 }

--- a/apis/v1/plugins.go
+++ b/apis/v1/plugins.go
@@ -15,74 +15,52 @@
 package v1
 
 // PluginManifest describes a frontend plugin discovered by the backend from a
-// labeled ConfigMap. It carries just enough for the host to fetch and
-// import() the right file. Page extensions (e.g. edge details, flow table
-// columns) are always registered by the plugin's own code, since the host
-// needs an actual function reference for those - Entry is always eagerly
-// imported for that purpose alone, whether or not Route/Federation are also
-// present. A whole-page route is the one exception - Route lets the host
-// build it from data alone, without running any of the plugin's code first
-// (see Route's own doc). A plugin can do both at once (e.g. an eager Entry
-// that only registers a page-extension renderer, plus a Route/Federation
-// pair describing an unrelated, separately-built, lazily-loaded page) -
-// Federation.RemoteEntry is deliberately its own file, not Entry, so the two
-// concerns never have to share one build artifact.
+// labeled ConfigMap. Page extensions (edge details, flow table columns) are
+// always registered by the plugin's own code - the host needs an actual
+// function reference for those. Routes is the one exception: it lets the
+// host build a whole-page route from data alone, without running the
+// plugin's code first.
 type PluginManifest struct {
 	Name    string `json:"name"`
 	Version string `json:"version"`
-	// Entry is always eagerly import()-ed by the host at startup, for
-	// whatever page-extension registration the plugin's code performs via
-	// antrea-ui-plugin-sdk (registerEdgeExtraRenderer() etc) - regardless of
-	// whether Route/Federation below are also present. A plugin with
-	// nothing to register eagerly still needs a (possibly no-op) Entry: it
-	// remains required.
+	// Entry is the plugin's entry file: a filename, a key in the same
+	// ConfigMap's data. Always eagerly import()-ed at startup, for whatever
+	// page-extension registration the plugin's code performs (see
+	// antrea-ui-plugin-sdk) - regardless of whether Routes/Federation below
+	// are also set.
 	Entry string `json:"entry"`
 
-	// Route optionally declares a whole-page route/sidebar entry for this
-	// plugin as data the host can act on immediately, instead of waiting for
-	// the plugin's own code to call registerRoute()/registerSidebarEntry()
-	// (see antrea-ui-plugin-sdk) as a side effect of loading it. Currently
-	// only meaningful paired with Federation (required whenever Route is
-	// set - see parsePluginConfigMap): Federation.ExposedModule is what the
-	// host actually mounts at Route.Path. A plain custom-element plugin has
-	// no equivalent here (there's no "Tag" field, unlike the SDK's
-	// PluginRoute) because registering such a route via code is already
-	// cheap - the data-only path exists specifically to defer loading a
-	// route's code, which only pays for itself when there's a nontrivial
-	// federated bundle behind it. Nothing prevents adding a lighter,
-	// Federation-less variant later if a use case for it shows up.
-	Route *PluginRoute `json:"route,omitempty"`
+	// Routes optionally declares whole-page routes as data, instead of the
+	// plugin's code calling registerRoute()/registerSidebarEntry() (see
+	// antrea-ui-plugin-sdk). A list because registerRoute() isn't limited to
+	// one call either. Requires Federation: each entry's ExposedModule is
+	// what the host actually mounts at its Path, and nothing else can supply
+	// that yet - a plain custom-element route is already cheap via code, so
+	// there's nothing here worth deferring for it.
+	Routes []PluginRoute `json:"routes,omitempty"`
 
-	// Federation optionally declares a module federation remote (e.g. a
-	// Native Federation "remoteEntry.json") the host can lazily load a
-	// component out of - normally paired with Route, to render at that
-	// route. Deliberately a file of its own rather than reusing Entry: Entry
-	// stays reserved for whatever a plugin needs eagerly loaded (page
-	// extensions), which may have nothing to do with, and may be far
-	// cheaper than, a lazily-loaded federated page.
+	// Federation optionally declares the plugin's module federation remote -
+	// its own file, not Entry, so an eager page extension and a lazily-loaded
+	// federated page never have to share one build artifact.
 	Federation *PluginFederation `json:"federation,omitempty"`
 }
 
-// PluginRoute is the data-only counterpart to the antrea-ui-plugin-sdk
-// registerRoute()/registerSidebarEntry() calls: same information (a path and
-// a sidebar label), just readable off the manifest instead of requiring the
-// plugin's code to run and call back into the host.
+// PluginRoute mirrors registerRoute()/registerSidebarEntry()'s
+// antrea-ui-plugin-sdk info, as data.
 type PluginRoute struct {
 	Path         string `json:"path"`
 	SidebarLabel string `json:"sidebarLabel"`
-	// Icon is optional SVG path "d" data for a 16x16 (viewBox "0 0 16 16")
-	// icon, matching PluginSidebarEntry.icon in antrea-ui-plugin-sdk.
+	// Icon is optional SVG path "d" data, 16x16 viewBox "0 0 16 16", matching
+	// PluginSidebarEntry.icon in antrea-ui-plugin-sdk.
 	Icon string `json:"icon,omitempty"`
+	// ExposedModule names which component Federation.RemoteEntry exposes for
+	// this route.
+	ExposedModule string `json:"exposedModule"`
 }
 
-// PluginFederation carries the two things a federation runtime needs beyond
-// what Entry already provides: its own remote entry file (see
-// PluginManifest's doc for why this isn't just Entry), and which of that
-// remote's exposed modules to load. Shared-dependency negotiation is
-// otherwise handled entirely by the remote entry file itself (e.g. by the
-// plugin's own federation.config.js at build time), so nothing else belongs
-// here.
+// PluginFederation is the plugin's federation remote entry file. Which
+// component to load from it is per-route (PluginRoute.ExposedModule), since
+// one remote can expose components for more than one route.
 type PluginFederation struct {
-	RemoteEntry   string `json:"remoteEntry"`
-	ExposedModule string `json:"exposedModule"`
+	RemoteEntry string `json:"remoteEntry"`
 }

--- a/apis/v1/plugins.go
+++ b/apis/v1/plugins.go
@@ -16,10 +16,52 @@ package v1
 
 // PluginManifest describes a frontend plugin discovered by the backend from a
 // labeled ConfigMap. It carries just enough for the host to fetch and
-// import() the right file; everything that affects the UI (routes, sidebar
-// entries, page extensions) is registered in the plugin's own code.
+// import() the right file. Page extensions (e.g. edge details, flow table
+// columns) are always registered by the plugin's own code, since the host
+// needs an actual function reference for those; a whole-page route is the
+// one exception - Route lets the host build it from data alone, without
+// running any of the plugin's code first (see Route's own doc).
 type PluginManifest struct {
 	Name    string `json:"name"`
 	Version string `json:"version"`
 	Entry   string `json:"entry"`
+
+	// Route optionally declares a whole-page route/sidebar entry for this
+	// plugin as data the host can act on immediately, instead of waiting for
+	// the plugin's own code to call registerRoute()/registerSidebarEntry()
+	// (see antrea-ui-plugin-sdk) as a side effect of loading it. Chiefly
+	// useful for a plugin loaded via module federation (see Federation),
+	// where the point of the exercise is to defer fetching/running the
+	// plugin's code until its route is actually visited - which requires the
+	// host to already know the route before that happens.
+	Route *PluginRoute `json:"route,omitempty"`
+
+	// Federation optionally declares that Entry is a module federation
+	// remote entry (e.g. a Native Federation "remoteEntry.json"), rather
+	// than a module the host can plainly import(). A host that understands
+	// this field loads ExposedModule out of it via its federation runtime
+	// instead; a host that doesn't (or a plugin that omits this field
+	// entirely) keeps using Entry as a plain ES module, unaffected.
+	Federation *PluginFederation `json:"federation,omitempty"`
+}
+
+// PluginRoute is the data-only counterpart to the antrea-ui-plugin-sdk
+// registerRoute()/registerSidebarEntry() calls: same information (a path and
+// a sidebar label), just readable off the manifest instead of requiring the
+// plugin's code to run and call back into the host.
+type PluginRoute struct {
+	Path         string `json:"path"`
+	SidebarLabel string `json:"sidebarLabel"`
+	// Icon is optional SVG path "d" data for a 16x16 (viewBox "0 0 16 16")
+	// icon, matching PluginSidebarEntry.icon in antrea-ui-plugin-sdk.
+	Icon string `json:"icon,omitempty"`
+}
+
+// PluginFederation carries the one extra piece of information a federation
+// runtime needs beyond a remote entry URL: which of that remote's exposed
+// modules to load. Shared-dependency negotiation is otherwise handled
+// entirely by the remote entry file itself (e.g. by the plugin's own
+// federation.config.js at build time), so nothing else belongs here.
+type PluginFederation struct {
+	ExposedModule string `json:"exposedModule"`
 }

--- a/client/web/antrea-ui/src/plugins.ts
+++ b/client/web/antrea-ui/src/plugins.ts
@@ -21,10 +21,11 @@
 // fetches that index and loads the plugins it lists at app startup.
 //
 // A plugin's ConfigMap data contains:
-//   - manifest.json: bare metadata (name/version/entry) — just enough to know which JS module
-//     to fetch and import(). It carries no UI-affecting fields; those are all registered in
-//     code (see below), so a plugin's actual shape (routes, sidebar entries, page extensions)
-//     is never split between JSON and JS.
+//   - manifest.json: bare metadata (name/version/entry), plus two fields this host doesn't act
+//     on (route/federation - see apis/v1/plugins.go) for a plugin whose whole page is a module
+//     federation remote, letting an Angular-based host lazily load it. entry is unaffected
+//     either way: it's always a plain ES module this host can import() unconditionally, exactly
+//     as below, regardless of whether a manifest also carries route/federation.
 //   - <entry>: an ES module that, as an import side effect, registers a custom element
 //     (customElements.define(tag, ...)) for anything it wants to render, and calls into the
 //     plugin registry below via @antrea/ui-plugin-sdk to tell the host about it.
@@ -115,10 +116,15 @@ export function getFlowTableColumnsProcessors(): FlowTableColumnsProcessor[] {
     return flowTableColumnsProcessors;
 }
 
+// route/federation are declared here for parity with apis/v1/plugins.go, but this host doesn't
+// act on them - it has no module federation loader, and has no reason to grow one, since it
+// keeps import()-ing entry eagerly for every plugin regardless (see loadPlugins() below).
 export interface PluginManifest {
     name: string;
     version: string;
     entry: string;
+    route?: { path: string; sidebarLabel: string; icon?: string };
+    federation?: { remoteEntry: string; exposedModule: string };
 }
 
 export async function loadPlugins(): Promise<PluginManifest[]> {

--- a/client/web/antrea-ui/src/plugins.ts
+++ b/client/web/antrea-ui/src/plugins.ts
@@ -22,10 +22,10 @@
 //
 // A plugin's ConfigMap data contains:
 //   - manifest.json: bare metadata (name/version/entry), plus two fields this host doesn't act
-//     on (route/federation - see apis/v1/plugins.go) for a plugin whose whole page is a module
-//     federation remote, letting an Angular-based host lazily load it. entry is unaffected
+//     on (routes/federation - see apis/v1/plugins.go) for a plugin whose page(s) are a module
+//     federation remote, letting an Angular-based host lazily load them. entry is unaffected
 //     either way: it's always a plain ES module this host can import() unconditionally, exactly
-//     as below, regardless of whether a manifest also carries route/federation.
+//     as below, regardless of whether a manifest also carries routes/federation.
 //   - <entry>: an ES module that, as an import side effect, registers a custom element
 //     (customElements.define(tag, ...)) for anything it wants to render, and calls into the
 //     plugin registry below via @antrea/ui-plugin-sdk to tell the host about it.
@@ -116,15 +116,15 @@ export function getFlowTableColumnsProcessors(): FlowTableColumnsProcessor[] {
     return flowTableColumnsProcessors;
 }
 
-// route/federation are declared here for parity with apis/v1/plugins.go, but this host doesn't
+// routes/federation are declared here for parity with apis/v1/plugins.go, but this host doesn't
 // act on them - it has no module federation loader, and has no reason to grow one, since it
 // keeps import()-ing entry eagerly for every plugin regardless (see loadPlugins() below).
 export interface PluginManifest {
     name: string;
     version: string;
     entry: string;
-    route?: { path: string; sidebarLabel: string; icon?: string };
-    federation?: { remoteEntry: string; exposedModule: string };
+    routes?: { path: string; sidebarLabel: string; icon?: string; exposedModule: string }[];
+    federation?: { remoteEntry: string };
 }
 
 export async function loadPlugins(): Promise<PluginManifest[]> {

--- a/client/web/antrea-ui/src/plugins.ts
+++ b/client/web/antrea-ui/src/plugins.ts
@@ -21,11 +21,11 @@
 // fetches that index and loads the plugins it lists at app startup.
 //
 // A plugin's ConfigMap data contains:
-//   - manifest.json: bare metadata (name/version/entry), plus two fields this host doesn't act
-//     on (routes/federation - see apis/v1/plugins.go) for a plugin whose page(s) are a module
-//     federation remote, letting an Angular-based host lazily load them. entry is unaffected
-//     either way: it's always a plain ES module this host can import() unconditionally, exactly
-//     as below, regardless of whether a manifest also carries routes/federation.
+//   - manifest.json: bare metadata (name/version/entry), plus a field this host doesn't act on
+//     (federation - see apis/v1/plugins.go) for a plugin whose page(s) are a module federation
+//     remote, letting an Angular-based host lazily load them. entry is unaffected either way:
+//     it's always a plain ES module this host can import() unconditionally, exactly as below,
+//     regardless of whether a manifest also carries federation.
 //   - <entry>: an ES module that, as an import side effect, registers a custom element
 //     (customElements.define(tag, ...)) for anything it wants to render, and calls into the
 //     plugin registry below via @antrea/ui-plugin-sdk to tell the host about it.
@@ -116,15 +116,17 @@ export function getFlowTableColumnsProcessors(): FlowTableColumnsProcessor[] {
     return flowTableColumnsProcessors;
 }
 
-// routes/federation are declared here for parity with apis/v1/plugins.go, but this host doesn't
-// act on them - it has no module federation loader, and has no reason to grow one, since it
-// keeps import()-ing entry eagerly for every plugin regardless (see loadPlugins() below).
+// federation is declared here for parity with apis/v1/plugins.go, but this host doesn't act on
+// it - it has no module federation loader, and has no reason to grow one, since it keeps
+// import()-ing entry eagerly for every plugin regardless (see loadPlugins() below).
 export interface PluginManifest {
     name: string;
     version: string;
     entry: string;
-    routes?: { path: string; sidebarLabel: string; icon?: string; exposedModule: string }[];
-    federation?: { remoteEntry: string };
+    federation?: {
+        remoteEntry: string;
+        routes: { path: string; sidebarLabel: string; icon?: string; exposedModule: string }[];
+    };
 }
 
 export async function loadPlugins(): Promise<PluginManifest[]> {

--- a/docs/plugins.md
+++ b/docs/plugins.md
@@ -66,19 +66,18 @@ complete, minimal example.
 | --- | --- | --- |
 | `name` | yes | Unique name; also the path segment used to serve the plugin, e.g. `/api/v1/plugins/<name>/`. |
 | `version` | yes | Informational only. |
-| `entry` | yes | Plugin's JS module filename; must be a key in the same ConfigMap's data. Always eagerly `import()`-ed by the host at startup, for whatever page-extension registration the plugin's code performs (see below) — independent of `routes`/`federation`. |
-| `routes` | no | `[{path, sidebarLabel, icon?, exposedModule}]` — one or more whole-page routes/sidebar entries as data, instead of registering them in code (see below). Currently requires `federation` alongside it. |
-| `federation` | no | `{remoteEntry}` — a [Native Federation](https://www.npmjs.com/package/@angular-architects/native-federation) remote (its own file, separate from `entry`) the host lazily loads a `routes` entry's `exposedModule` out of, only once that entry's route is actually visited. |
+| `entry` | yes | Plugin's JS module filename; must be a key in the same ConfigMap's data. Always eagerly `import()`-ed by the host at startup, for whatever page-extension registration the plugin's code performs (see below) — independent of `federation`. |
+| `federation` | no | `{remoteEntry, routes: [{path, sidebarLabel, icon?, exposedModule}]}` — a [Native Federation](https://www.npmjs.com/package/@angular-architects/native-federation) remote (its own file, separate from `entry`) plus the whole-page routes/sidebar entries it serves, as data instead of registering them in code (see below). The host lazily loads a route's `exposedModule` out of `remoteEntry`, only once that route is actually visited. |
 
 For most plugins, that's the whole schema: the manifest only carries enough
 for the host to fetch and `import()` the right file, and everything that
 affects the UI (routes, sidebar entries, page extensions) is registered in
 code, via `@antrea/ui-plugin-sdk`, so a plugin's actual shape is never split
-between JSON and JS. `routes`/`federation` are the one exception, for a
-plugin whose page(s) are a module federation remote — deferring code
-execution until a route is visited requires the host to know the route
-beforehand, which requires it to be data rather than something only running
-the plugin's code would reveal.
+between JSON and JS. `federation` is the one exception, for a plugin whose
+page(s) are a module federation remote — deferring code execution until a
+route is visited requires the host to know the route beforehand, which
+requires it to be data rather than something only running the plugin's code
+would reveal.
 
 ## Writing a plugin
 

--- a/docs/plugins.md
+++ b/docs/plugins.md
@@ -66,19 +66,19 @@ complete, minimal example.
 | --- | --- | --- |
 | `name` | yes | Unique name; also the path segment used to serve the plugin, e.g. `/api/v1/plugins/<name>/`. |
 | `version` | yes | Informational only. |
-| `entry` | yes | Plugin's JS module filename; must be a key in the same ConfigMap's data. Always eagerly `import()`-ed by the host at startup, for whatever page-extension registration the plugin's code performs (see below) — independent of `route`/`federation`. |
-| `route` | no | `{path, sidebarLabel, icon?}` — a whole-page route/sidebar entry as data, instead of registering one in code (see below). Currently requires `federation` alongside it. |
-| `federation` | no | `{remoteEntry, exposedModule}` — a [Native Federation](https://www.npmjs.com/package/@angular-architects/native-federation) remote (its own file, separate from `entry`) the host lazily loads a component out of at `route.path`, only once that route is actually visited. |
+| `entry` | yes | Plugin's JS module filename; must be a key in the same ConfigMap's data. Always eagerly `import()`-ed by the host at startup, for whatever page-extension registration the plugin's code performs (see below) — independent of `routes`/`federation`. |
+| `routes` | no | `[{path, sidebarLabel, icon?, exposedModule}]` — one or more whole-page routes/sidebar entries as data, instead of registering them in code (see below). Currently requires `federation` alongside it. |
+| `federation` | no | `{remoteEntry}` — a [Native Federation](https://www.npmjs.com/package/@angular-architects/native-federation) remote (its own file, separate from `entry`) the host lazily loads a `routes` entry's `exposedModule` out of, only once that entry's route is actually visited. |
 
 For most plugins, that's the whole schema: the manifest only carries enough
 for the host to fetch and `import()` the right file, and everything that
 affects the UI (routes, sidebar entries, page extensions) is registered in
 code, via `@antrea/ui-plugin-sdk`, so a plugin's actual shape is never split
-between JSON and JS. `route`/`federation` are the one exception, for a plugin
-whose page is a module federation remote — deferring code execution until
-the route is visited requires the host to know the route beforehand, which
-requires it to be data rather than something only running the plugin's code
-would reveal.
+between JSON and JS. `routes`/`federation` are the one exception, for a
+plugin whose page(s) are a module federation remote — deferring code
+execution until a route is visited requires the host to know the route
+beforehand, which requires it to be data rather than something only running
+the plugin's code would reveal.
 
 ## Writing a plugin
 

--- a/docs/plugins.md
+++ b/docs/plugins.md
@@ -67,7 +67,7 @@ complete, minimal example.
 | `name` | yes | Unique name; also the path segment used to serve the plugin, e.g. `/api/v1/plugins/<name>/`. |
 | `version` | yes | Informational only. |
 | `entry` | yes | Plugin's JS module filename; must be a key in the same ConfigMap's data. Always eagerly `import()`-ed by the host at startup, for whatever page-extension registration the plugin's code performs (see below) — independent of `federation`. |
-| `federation` | no | `{remoteEntry, routes: [{path, sidebarLabel, icon?, exposedModule}]}` — a [Native Federation](https://www.npmjs.com/package/@angular-architects/native-federation) remote (its own file, separate from `entry`) plus the whole-page routes/sidebar entries it serves, as data instead of registering them in code (see below). The host lazily loads a route's `exposedModule` out of `remoteEntry`, only once that route is actually visited. |
+| `federation` | no | `{remoteEntry, routes: [{path, sidebarLabel, icon?, exposedModule}]}` — a [Native Federation](https://www.npmjs.com/package/@angular-architects/native-federation) remote (its own file, separate from `entry`) plus the whole-page routes/sidebar entries it serves, as data instead of registering them in code (see below). Antrea UI's own frontend has no module federation loader and ignores this field entirely (see `plugins.ts`); it's consumed by a separate, out-of-tree Angular-based host, which lazily loads a route's `exposedModule` out of `remoteEntry`, only once that route is actually visited. |
 
 For most plugins, that's the whole schema: the manifest only carries enough
 for the host to fetch and `import()` the right file, and everything that

--- a/docs/plugins.md
+++ b/docs/plugins.md
@@ -66,13 +66,19 @@ complete, minimal example.
 | --- | --- | --- |
 | `name` | yes | Unique name; also the path segment used to serve the plugin, e.g. `/api/v1/plugins/<name>/`. |
 | `version` | yes | Informational only. |
-| `entry` | yes | Plugin's JS module filename; must be a key in the same ConfigMap's data. |
+| `entry` | yes | Plugin's JS module filename; must be a key in the same ConfigMap's data. Always eagerly `import()`-ed by the host at startup, for whatever page-extension registration the plugin's code performs (see below) — independent of `route`/`federation`. |
+| `route` | no | `{path, sidebarLabel, icon?}` — a whole-page route/sidebar entry as data, instead of registering one in code (see below). Currently requires `federation` alongside it. |
+| `federation` | no | `{remoteEntry, exposedModule}` — a [Native Federation](https://www.npmjs.com/package/@angular-architects/native-federation) remote (its own file, separate from `entry`) the host lazily loads a component out of at `route.path`, only once that route is actually visited. |
 
-That's the whole schema — the manifest only carries enough for the host to
-fetch and `import()` the right file. Everything that affects the UI (routes,
-sidebar entries, page extensions) is registered in code, via
-`@antrea/ui-plugin-sdk`, so a plugin's actual shape is never split between
-JSON and JS.
+For most plugins, that's the whole schema: the manifest only carries enough
+for the host to fetch and `import()` the right file, and everything that
+affects the UI (routes, sidebar entries, page extensions) is registered in
+code, via `@antrea/ui-plugin-sdk`, so a plugin's actual shape is never split
+between JSON and JS. `route`/`federation` are the one exception, for a plugin
+whose page is a module federation remote — deferring code execution until
+the route is visited requires the host to know the route beforehand, which
+requires it to be data rather than something only running the plugin's code
+would reveal.
 
 ## Writing a plugin
 

--- a/docs/plugins.md
+++ b/docs/plugins.md
@@ -100,10 +100,12 @@ A manifest declaring `federation`:
 }
 ```
 
-The backend rejects a plugin's ConfigMap outright (logging why, and serving
-neither the manifest nor its files) if any of the following don't hold —
-each is a case that would otherwise surface only as a broken route or a
-silent skip once the plugin is already installed:
+The backend refuses to load a plugin's ConfigMap (logging why) if any of the
+following don't hold — each is a case that would otherwise surface only as
+a broken route or a silent skip once the plugin is already installed. A
+ConfigMap that fails these checks on an update, rather than on first load,
+leaves the previously loaded version in place until the ConfigMap is fixed
+or deleted:
 
 - `federation.remoteEntry` must be a key in the same ConfigMap's data, and
   must not be the same key as `entry` — the host always `import()`s `entry`
@@ -111,17 +113,22 @@ silent skip once the plugin is already installed:
 - `federation.routes` must be non-empty — a remote with nothing to mount is
   meaningless on its own.
 - Each route needs `path`, `sidebarLabel`, and `exposedModule`.
-- `path` may not fall under a path nginx proxies straight to the backend
-  (currently `api`, `auth`, e.g. `/api/v1/foo` or `/authors`) — that would
-  install and navigate fine client-side, then 404 on a hard refresh or a
-  direct link.
+- `path` may not be the root path (`/`) or fall under a path nginx proxies
+  straight to the backend (currently `api`, `auth`, e.g. `/api/v1/foo` or
+  `/authors`) — the former collides with the host's own home page, the
+  latter would install and navigate fine client-side, then 404 on a hard
+  refresh or a direct link.
 - `path` may not duplicate another route's `path` in the same manifest
-  (leading/trailing/doubled slashes ignored when comparing).
+  (leading/trailing/doubled slashes, and `.`/`..` segments, ignored when
+  comparing).
 
 A route `path` colliding with another, already-installed plugin's route
-`path` is a separate, softer case: both ConfigMaps still parse and load, but
-`GET /api/v1/plugins/index.json` keeps only the earlier one (by ConfigMap
-name) and drops the later plugin entirely, logging why — the same
+`path` is a separate, softer case, resolved once ConfigMaps are already
+loaded rather than at parse time: whichever plugin's ConfigMap name sorts
+first keeps the route, and the later plugin just loses that one route (and
+its sidebar entry) from `GET /api/v1/plugins/index.json` — the rest of its
+manifest, including `entry`, is unaffected. Only if every one of a plugin's
+routes collides is the whole plugin dropped from the index, the same
 resolution as two plugins declaring the same `name`.
 
 ## Writing a plugin

--- a/docs/plugins.md
+++ b/docs/plugins.md
@@ -66,7 +66,7 @@ complete, minimal example.
 | --- | --- | --- |
 | `name` | yes | Unique name; also the path segment used to serve the plugin, e.g. `/api/v1/plugins/<name>/`. |
 | `version` | yes | Informational only. |
-| `entry` | yes | Plugin's JS module filename; must be a key in the same ConfigMap's data. Always eagerly `import()`-ed by the host at startup, for whatever page-extension registration the plugin's code performs (see below) — independent of `federation`. |
+| `entry` | yes | Plugin's JS module filename; must be a key in the same ConfigMap's data. Always eagerly `import()`-ed by the host at startup, for whatever page-extension registration the plugin's code performs (see below) — independent of `federation`. Required even for a plugin whose only page(s) are a `federation` remote with no other page-extension registration; such a plugin still needs a real ES module here, distinct from `federation.remoteEntry` — see below. |
 | `federation` | no | `{remoteEntry, routes: [{path, sidebarLabel, icon?, exposedModule}]}` — a [Native Federation](https://www.npmjs.com/package/@angular-architects/native-federation) remote (its own file, separate from `entry`) plus the whole-page routes/sidebar entries it serves, as data instead of registering them in code (see below). Antrea UI's own frontend has no module federation loader and ignores this field entirely (see `plugins.ts`); it's consumed by a separate, out-of-tree Angular-based host, which lazily loads a route's `exposedModule` out of `remoteEntry`, only once that route is actually visited. |
 
 For most plugins, that's the whole schema: the manifest only carries enough
@@ -78,6 +78,51 @@ page(s) are a module federation remote — deferring code execution until a
 route is visited requires the host to know the route beforehand, which
 requires it to be data rather than something only running the plugin's code
 would reveal.
+
+A manifest declaring `federation`:
+
+```json
+{
+  "name": "policy-management",
+  "version": "0.2.0",
+  "entry": "index.js",
+  "federation": {
+    "remoteEntry": "remoteEntry.json",
+    "routes": [
+      {
+        "path": "/policies",
+        "sidebarLabel": "Policy Management",
+        "icon": "M0 0h16v16H0z",
+        "exposedModule": "./PolicyManagementPage"
+      }
+    ]
+  }
+}
+```
+
+The backend rejects a plugin's ConfigMap outright (logging why, and serving
+neither the manifest nor its files) if any of the following don't hold —
+each is a case that would otherwise surface only as a broken route or a
+silent skip once the plugin is already installed:
+
+- `federation.remoteEntry` must be a key in the same ConfigMap's data, and
+  must not be the same key as `entry` — the host always `import()`s `entry`
+  as a plain ES module, which a federation remote entry is not.
+- `federation.routes` must be non-empty — a remote with nothing to mount is
+  meaningless on its own.
+- Each route needs `path`, `sidebarLabel`, and `exposedModule`.
+- `path` may not fall under a path nginx proxies straight to the backend
+  (currently `api`, `auth`, e.g. `/api/v1/foo` or `/authors`) — that would
+  install and navigate fine client-side, then 404 on a hard refresh or a
+  direct link.
+- `path` may not duplicate another route's `path` in the same manifest
+  (leading/trailing/doubled slashes ignored when comparing).
+
+A route `path` colliding with another, already-installed plugin's route
+`path` is a separate, softer case: both ConfigMaps still parse and load, but
+`GET /api/v1/plugins/index.json` keeps only the earlier one (by ConfigMap
+name) and drops the later plugin entirely, logging why — the same
+resolution as two plugins declaring the same `name`.
 
 ## Writing a plugin
 

--- a/pkg/plugins/registry.go
+++ b/pkg/plugins/registry.go
@@ -151,6 +151,12 @@ func parsePluginConfigMap(cm *corev1.ConfigMap) (*pluginEntry, error) {
 	if _, ok := files[manifest.Entry]; !ok {
 		return nil, fmt.Errorf("entry file %q referenced by manifest not found in ConfigMap", manifest.Entry)
 	}
+	if manifest.Route != nil && manifest.Route.Path == "" {
+		return nil, fmt.Errorf("manifest's route is missing 'path'")
+	}
+	if manifest.Federation != nil && manifest.Federation.ExposedModule == "" {
+		return nil, fmt.Errorf("manifest's federation is missing 'exposedModule'")
+	}
 	return &pluginEntry{manifest: manifest, files: files}, nil
 }
 

--- a/pkg/plugins/registry.go
+++ b/pkg/plugins/registry.go
@@ -22,6 +22,7 @@ package plugins
 import (
 	"encoding/json"
 	"fmt"
+	"path"
 	"sort"
 	"strings"
 	"sync"
@@ -37,6 +38,32 @@ import (
 )
 
 const manifestFileName = "manifest.json"
+
+// reservedRoutePrefixes mirrors the nginx config's location blocks
+// (_nginx_conf.tpl: "location /api", "location /auth"), which are plain
+// string prefixes, not path-segment matches: nginx proxies any URI
+// beginning with "/api" or "/auth" - "/apidocs", "/api", "/authors" all
+// included - straight to the backend, bypassing the SPA. A manifest route
+// under one of these would install and navigate fine client-side, then
+// 404 on a hard refresh or a direct link.
+var reservedRoutePrefixes = []string{"api", "auth"}
+
+// normalizeRoutePath collapses a route path to the form used for reservation
+// and duplicate checks, so "/policies", "policies", "//policies" and
+// "/policies/" are all recognized as the same path (and ".." segments can't
+// be used to escape the comparison).
+func normalizeRoutePath(p string) string {
+	return strings.Trim(path.Clean("/"+p), "/")
+}
+
+func isReservedRoutePath(normalized string) bool {
+	for _, prefix := range reservedRoutePrefixes {
+		if strings.HasPrefix(normalized, prefix) {
+			return true
+		}
+	}
+	return false
+}
 
 type pluginEntry struct {
 	manifest apisv1.PluginManifest
@@ -156,6 +183,9 @@ func parsePluginConfigMap(cm *corev1.ConfigMap) (*pluginEntry, error) {
 		if manifest.Federation.RemoteEntry == "" {
 			return nil, fmt.Errorf("manifest's federation is missing 'remoteEntry'")
 		}
+		if manifest.Federation.RemoteEntry == manifest.Entry {
+			return nil, fmt.Errorf("manifest's 'federation.remoteEntry' must not be the same file as 'entry' - the host always import()s 'entry' as a plain ES module, which a federation remote entry is not")
+		}
 		if _, ok := files[manifest.Federation.RemoteEntry]; !ok {
 			return nil, fmt.Errorf("remote entry file %q referenced by manifest's federation not found in ConfigMap", manifest.Federation.RemoteEntry)
 		}
@@ -173,22 +203,22 @@ func parsePluginConfigMap(cm *corev1.ConfigMap) (*pluginEntry, error) {
 			if route.ExposedModule == "" {
 				return nil, fmt.Errorf("manifest's 'federation.routes[%d]' is missing 'exposedModule'", i)
 			}
-			// The one reservation the backend can enforce on a route's Path itself - "api/" is
-			// its own reserved prefix (see GetPluginFile), not something specific to any one
-			// frontend. A route colliding with a given host's own built-in pages (e.g.
-			// "/settings") is instead the host's job to reject, the same way it already does for
-			// code-registered routes (see plugins.ts's RESERVED_PATHS/dedupeByPath in the
-			// out-of-tree, module-federation-aware host - Antrea UI's own frontend ignores
-			// 'federation' altogether) - the backend has no way to know a given host's built-in
-			// path list.
-			trimmed := strings.TrimPrefix(route.Path, "/")
-			if strings.HasPrefix(trimmed, "api/") {
-				return nil, fmt.Errorf("manifest's 'federation.routes[%d].path' %q falls under the reserved 'api/' prefix", i, route.Path)
+			// The one reservation the backend can enforce on a route's Path itself is the
+			// nginx-served prefixes (see reservedRoutePrefixes), not something specific to any
+			// one frontend. A route colliding with a given host's own built-in pages (e.g.
+			// "/settings") is instead the host's job to reject, the same way this repo's
+			// plugins.ts (RESERVED_PATHS/dedupeByPath) already does for its own code-registered
+			// routes - the backend has no way to know a given host's built-in path list, and the
+			// out-of-tree, module-federation-aware host that actually consumes 'federation' needs
+			// its own equivalent for manifest-declared routes.
+			normalized := normalizeRoutePath(route.Path)
+			if isReservedRoutePath(normalized) {
+				return nil, fmt.Errorf("manifest's 'federation.routes[%d].path' %q falls under a reserved prefix (%s)", i, route.Path, strings.Join(reservedRoutePrefixes, ", "))
 			}
-			if other, ok := seenPaths[trimmed]; ok {
+			if other, ok := seenPaths[normalized]; ok {
 				return nil, fmt.Errorf("manifest's 'federation.routes[%d].path' %q duplicates earlier route %q in the same manifest", i, route.Path, other)
 			}
-			seenPaths[trimmed] = route.Path
+			seenPaths[normalized] = route.Path
 		}
 	}
 	return &pluginEntry{manifest: manifest, files: files}, nil
@@ -207,22 +237,41 @@ func (r *Registry) sortedConfigMapNames() []string {
 }
 
 // Index returns the current set of plugin manifests, deduplicated by
-// manifest name. If two ConfigMaps declare the same plugin name, the one
-// whose backing ConfigMap name sorts first wins and the other is dropped
-// (and logged) - mirrors the frontend's dedupeByPath in plugins.ts.
+// manifest name and by federation route path. If two ConfigMaps declare the
+// same plugin name, or two different plugins declare a colliding federation
+// route path, the one whose backing ConfigMap name sorts first wins and the
+// other is dropped (and logged) - mirrors the frontend's dedupeByPath in
+// plugins.ts, which does the same for code-registered routes.
 func (r *Registry) Index() []apisv1.PluginManifest {
 	r.mu.RLock()
 	defer r.mu.RUnlock()
 
-	seen := make(map[string]string) // plugin name -> ConfigMap name that claimed it
+	seenNames := make(map[string]string)      // plugin name -> ConfigMap name that claimed it
+	seenRoutePaths := make(map[string]string) // normalized route path -> plugin name that claimed it
 	manifests := make([]apisv1.PluginManifest, 0, len(r.plugins))
 	for _, cmName := range r.sortedConfigMapNames() {
 		entry := r.plugins[cmName]
-		if owner, ok := seen[entry.manifest.Name]; ok {
+		if owner, ok := seenNames[entry.manifest.Name]; ok {
 			r.logger.Info("Duplicate plugin name, dropping", "plugin", entry.manifest.Name, "configMap", cmName, "keptConfigMap", owner)
 			continue
 		}
-		seen[entry.manifest.Name] = cmName
+		if entry.manifest.Federation != nil {
+			conflict := ""
+			for _, route := range entry.manifest.Federation.Routes {
+				if owner, ok := seenRoutePaths[normalizeRoutePath(route.Path)]; ok {
+					conflict = owner
+					break
+				}
+			}
+			if conflict != "" {
+				r.logger.Info("Plugin's federation route path collides with an earlier plugin, dropping", "plugin", entry.manifest.Name, "configMap", cmName, "collidesWithPlugin", conflict)
+				continue
+			}
+			for _, route := range entry.manifest.Federation.Routes {
+				seenRoutePaths[normalizeRoutePath(route.Path)] = entry.manifest.Name
+			}
+		}
+		seenNames[entry.manifest.Name] = cmName
 		manifests = append(manifests, entry.manifest)
 	}
 	return manifests

--- a/pkg/plugins/registry.go
+++ b/pkg/plugins/registry.go
@@ -152,11 +152,6 @@ func parsePluginConfigMap(cm *corev1.ConfigMap) (*pluginEntry, error) {
 	if _, ok := files[manifest.Entry]; !ok {
 		return nil, fmt.Errorf("entry file %q referenced by manifest not found in ConfigMap", manifest.Entry)
 	}
-	// See PluginRoute's doc: there's currently nothing else that can supply what the host mounts
-	// at any of Routes' Paths.
-	if len(manifest.Routes) > 0 && manifest.Federation == nil {
-		return nil, fmt.Errorf("manifest's 'routes' requires 'federation'")
-	}
 	if manifest.Federation != nil {
 		if manifest.Federation.RemoteEntry == "" {
 			return nil, fmt.Errorf("manifest's federation is missing 'remoteEntry'")
@@ -164,31 +159,31 @@ func parsePluginConfigMap(cm *corev1.ConfigMap) (*pluginEntry, error) {
 		if _, ok := files[manifest.Federation.RemoteEntry]; !ok {
 			return nil, fmt.Errorf("remote entry file %q referenced by manifest's federation not found in ConfigMap", manifest.Federation.RemoteEntry)
 		}
-	}
-	seenPaths := make(map[string]bool, len(manifest.Routes))
-	for i, route := range manifest.Routes {
-		if route.Path == "" {
-			return nil, fmt.Errorf("manifest's 'routes[%d]' is missing 'path'", i)
+		seenPaths := make(map[string]bool, len(manifest.Federation.Routes))
+		for i, route := range manifest.Federation.Routes {
+			if route.Path == "" {
+				return nil, fmt.Errorf("manifest's 'federation.routes[%d]' is missing 'path'", i)
+			}
+			if route.SidebarLabel == "" {
+				return nil, fmt.Errorf("manifest's 'federation.routes[%d]' is missing 'sidebarLabel'", i)
+			}
+			if route.ExposedModule == "" {
+				return nil, fmt.Errorf("manifest's 'federation.routes[%d]' is missing 'exposedModule'", i)
+			}
+			// The one reservation the backend can enforce on a route's Path itself - "api/" is
+			// its own reserved prefix (see GetPluginFile), not something specific to any one
+			// frontend. A route colliding with a given host's own built-in pages (e.g.
+			// "/settings") is instead the host's job to reject, the same way it already does for
+			// code-registered routes (see plugins.ts's RESERVED_PATHS/dedupeByPath in either
+			// frontend) - the backend has no way to know a given host's built-in path list.
+			if trimmed := strings.TrimPrefix(route.Path, "/"); strings.HasPrefix(trimmed, "api/") {
+				return nil, fmt.Errorf("manifest's 'federation.routes[%d].path' %q falls under the reserved 'api/' prefix", i, route.Path)
+			}
+			if seenPaths[route.Path] {
+				return nil, fmt.Errorf("manifest's 'federation.routes[%d].path' %q duplicates an earlier route in the same manifest", i, route.Path)
+			}
+			seenPaths[route.Path] = true
 		}
-		if route.SidebarLabel == "" {
-			return nil, fmt.Errorf("manifest's 'routes[%d]' is missing 'sidebarLabel'", i)
-		}
-		if route.ExposedModule == "" {
-			return nil, fmt.Errorf("manifest's 'routes[%d]' is missing 'exposedModule'", i)
-		}
-		// The one reservation the backend can enforce on a route's Path itself - "api/" is its
-		// own reserved prefix (see GetPluginFile), not something specific to any one frontend. A
-		// route colliding with a given host's own built-in pages (e.g. "/settings") is instead
-		// the host's job to reject, the same way it already does for code-registered routes (see
-		// plugins.ts's RESERVED_PATHS/dedupeByPath in either frontend) - the backend has no way
-		// to know a given host's built-in path list.
-		if trimmed := strings.TrimPrefix(route.Path, "/"); strings.HasPrefix(trimmed, "api/") {
-			return nil, fmt.Errorf("manifest's 'routes[%d].path' %q falls under the reserved 'api/' prefix", i, route.Path)
-		}
-		if seenPaths[route.Path] {
-			return nil, fmt.Errorf("manifest's 'routes[%d].path' %q duplicates an earlier route in the same manifest", i, route.Path)
-		}
-		seenPaths[route.Path] = true
 	}
 	return &pluginEntry{manifest: manifest, files: files}, nil
 }

--- a/pkg/plugins/registry.go
+++ b/pkg/plugins/registry.go
@@ -56,7 +56,15 @@ func normalizeRoutePath(p string) string {
 	return strings.Trim(path.Clean("/"+p), "/")
 }
 
+// isReservedRoutePath reports whether normalized (already run through
+// normalizeRoutePath) is off-limits for a manifest-declared route: it falls
+// under one of reservedRoutePrefixes, or it's the empty string - the root
+// path, which normalizeRoutePath also collapses "/", "." and ".." to, and
+// which plugins.ts's own RESERVED_PATHS reserves unconditionally (its "").
 func isReservedRoutePath(normalized string) bool {
+	if normalized == "" {
+		return true
+	}
 	for _, prefix := range reservedRoutePrefixes {
 		if strings.HasPrefix(normalized, prefix) {
 			return true
@@ -203,9 +211,9 @@ func parsePluginConfigMap(cm *corev1.ConfigMap) (*pluginEntry, error) {
 			if route.ExposedModule == "" {
 				return nil, fmt.Errorf("manifest's 'federation.routes[%d]' is missing 'exposedModule'", i)
 			}
-			// The one reservation the backend can enforce on a route's Path itself is the
-			// nginx-served prefixes (see reservedRoutePrefixes), not something specific to any
-			// one frontend. A route colliding with a given host's own built-in pages (e.g.
+			// The reservations the backend can enforce on a route's Path itself are the root
+			// path and the nginx-served prefixes (see isReservedRoutePath), neither specific to
+			// any one frontend. A route colliding with a given host's own built-in pages (e.g.
 			// "/settings") is instead the host's job to reject, the same way this repo's
 			// plugins.ts (RESERVED_PATHS/dedupeByPath) already does for its own code-registered
 			// routes - the backend has no way to know a given host's built-in path list, and the
@@ -213,7 +221,7 @@ func parsePluginConfigMap(cm *corev1.ConfigMap) (*pluginEntry, error) {
 			// its own equivalent for manifest-declared routes.
 			normalized := normalizeRoutePath(route.Path)
 			if isReservedRoutePath(normalized) {
-				return nil, fmt.Errorf("manifest's 'federation.routes[%d].path' %q falls under a reserved prefix (%s)", i, route.Path, strings.Join(reservedRoutePrefixes, ", "))
+				return nil, fmt.Errorf("manifest's 'federation.routes[%d].path' %q is the root path or falls under a reserved prefix (%s)", i, route.Path, strings.Join(reservedRoutePrefixes, ", "))
 			}
 			if other, ok := seenPaths[normalized]; ok {
 				return nil, fmt.Errorf("manifest's 'federation.routes[%d].path' %q duplicates earlier route %q in the same manifest", i, route.Path, other)
@@ -237,11 +245,34 @@ func (r *Registry) sortedConfigMapNames() []string {
 }
 
 // Index returns the current set of plugin manifests, deduplicated by
-// manifest name and by federation route path. If two ConfigMaps declare the
-// same plugin name, or two different plugins declare a colliding federation
-// route path, the one whose backing ConfigMap name sorts first wins and the
-// other is dropped (and logged) - mirrors the frontend's dedupeByPath in
-// plugins.ts, which does the same for code-registered routes.
+// manifest name and by federation route path.
+//
+// If two ConfigMaps declare the same plugin name, the one whose backing
+// ConfigMap name sorts first wins outright; the other is dropped (and
+// logged) in full, including its 'entry' - File would otherwise still serve
+// files for the loser, which Index no longer lists.
+//
+// If two different plugins' federation routes collide on path, only the
+// colliding routes are dropped from the later plugin (by ConfigMap name
+// sort), not the whole manifest - unlike the plugin-name case, 'entry' is
+// still eagerly import()ed by every listed manifest regardless of
+// 'federation' (see PluginManifest.Entry), so dropping the manifest would
+// cost that plugin's page-extension registrations over a route only an
+// out-of-tree, federation-aware host ever mounts. This differs from the
+// frontend's dedupeByPath in plugins.ts in the same way: dedupeByPath also
+// drops individual routes rather than a whole plugin, but its winner is
+// registration order (whichever plugin's entry module ran first), not
+// ConfigMap name sort. If every one of a plugin's routes collides, its
+// federation is left with no routes to serve, which is as meaningless as
+// the empty-routes case parsePluginConfigMap already rejects, so the whole
+// manifest is dropped instead - same as the plugin-name case.
+//
+// Either way, a plugin name is claimed by the first ConfigMap that reaches
+// it in sort order, whether or not that ConfigMap's manifest ends up listed
+// - a name left unclaimed just because its manifest was dropped for an
+// all-routes collision would let a later ConfigMap reusing that name win
+// the name outright in this loop, while File() (which walks the same order
+// independently) kept resolving it to the first, dropped, ConfigMap.
 func (r *Registry) Index() []apisv1.PluginManifest {
 	r.mu.RLock()
 	defer r.mu.RUnlock()
@@ -255,32 +286,49 @@ func (r *Registry) Index() []apisv1.PluginManifest {
 			r.logger.Info("Duplicate plugin name, dropping", "plugin", entry.manifest.Name, "configMap", cmName, "keptConfigMap", owner)
 			continue
 		}
-		if entry.manifest.Federation != nil {
-			conflict := ""
-			for _, route := range entry.manifest.Federation.Routes {
-				if owner, ok := seenRoutePaths[normalizeRoutePath(route.Path)]; ok {
-					conflict = owner
-					break
+
+		manifest := entry.manifest
+		if manifest.Federation != nil {
+			kept := make([]apisv1.PluginRoute, 0, len(manifest.Federation.Routes))
+			for _, route := range manifest.Federation.Routes {
+				normalized := normalizeRoutePath(route.Path)
+				if owner, ok := seenRoutePaths[normalized]; ok {
+					r.logger.Info("Plugin's federation route path collides with an earlier plugin, dropping the route", "plugin", manifest.Name, "configMap", cmName, "path", route.Path, "collidesWithPlugin", owner)
+					continue
 				}
+				seenRoutePaths[normalized] = manifest.Name
+				kept = append(kept, route)
 			}
-			if conflict != "" {
-				r.logger.Info("Plugin's federation route path collides with an earlier plugin, dropping", "plugin", entry.manifest.Name, "configMap", cmName, "collidesWithPlugin", conflict)
+			if len(kept) == 0 {
+				r.logger.Info("All of plugin's federation routes collided with an earlier plugin, dropping the plugin", "plugin", manifest.Name, "configMap", cmName)
+				// Still claim the name: this ConfigMap is the one File() would
+				// otherwise serve for it (sortedConfigMapNames order matches this
+				// loop's), and leaving it unclaimed would let a later ConfigMap
+				// reusing the same name win Index() while File() kept resolving
+				// to this one.
+				seenNames[manifest.Name] = cmName
 				continue
 			}
-			for _, route := range entry.manifest.Federation.Routes {
-				seenRoutePaths[normalizeRoutePath(route.Path)] = entry.manifest.Name
+			if len(kept) != len(manifest.Federation.Routes) {
+				federation := *manifest.Federation
+				federation.Routes = kept
+				manifest.Federation = &federation
 			}
 		}
-		seenNames[entry.manifest.Name] = cmName
-		manifests = append(manifests, entry.manifest)
+
+		seenNames[manifest.Name] = cmName
+		manifests = append(manifests, manifest)
 	}
 	return manifests
 }
 
 // File returns the contents of filename belonging to the plugin named
 // pluginName, as currently known to the registry. When the plugin name is
-// claimed by more than one ConfigMap, it resolves to the same one Index()
-// would keep.
+// claimed by more than one ConfigMap, it resolves to the ConfigMap that
+// claimed the name in Index() - usually the one whose manifest Index()
+// lists, except when every one of that manifest's federation routes
+// collided and Index() dropped it entirely while still leaving it holding
+// the name (see Index).
 func (r *Registry) File(pluginName, filename string) ([]byte, bool) {
 	r.mu.RLock()
 	defer r.mu.RUnlock()

--- a/pkg/plugins/registry.go
+++ b/pkg/plugins/registry.go
@@ -23,6 +23,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"sort"
+	"strings"
 	"sync"
 
 	"github.com/go-logr/logr"
@@ -151,8 +152,27 @@ func parsePluginConfigMap(cm *corev1.ConfigMap) (*pluginEntry, error) {
 	if _, ok := files[manifest.Entry]; !ok {
 		return nil, fmt.Errorf("entry file %q referenced by manifest not found in ConfigMap", manifest.Entry)
 	}
-	if manifest.Route != nil && manifest.Route.Path == "" {
-		return nil, fmt.Errorf("manifest's route is missing 'path'")
+	if manifest.Route != nil {
+		if manifest.Route.Path == "" {
+			return nil, fmt.Errorf("manifest is missing 'route.path'")
+		}
+		if manifest.Route.SidebarLabel == "" {
+			return nil, fmt.Errorf("manifest is missing 'route.sidebarLabel'")
+		}
+		// See PluginRoute's doc: there's currently nothing else that can supply what the host
+		// mounts at Route.Path.
+		if manifest.Federation == nil {
+			return nil, fmt.Errorf("manifest's 'route' requires 'federation'")
+		}
+		// The one reservation the backend can enforce on Route.Path itself - "api/" is its own
+		// reserved prefix (see GetPluginFile), not something specific to any one frontend. A
+		// route colliding with a given host's own built-in pages (e.g. "/settings") is instead
+		// the host's job to reject, the same way it already does for code-registered routes
+		// (see plugins.ts's RESERVED_PATHS/dedupeByPath in either frontend) - the backend has no
+		// way to know a given host's built-in path list.
+		if trimmed := strings.TrimPrefix(manifest.Route.Path, "/"); strings.HasPrefix(trimmed, "api/") {
+			return nil, fmt.Errorf("manifest's 'route.path' %q falls under the reserved 'api/' prefix", manifest.Route.Path)
+		}
 	}
 	if manifest.Federation != nil {
 		if manifest.Federation.RemoteEntry == "" {

--- a/pkg/plugins/registry.go
+++ b/pkg/plugins/registry.go
@@ -152,38 +152,43 @@ func parsePluginConfigMap(cm *corev1.ConfigMap) (*pluginEntry, error) {
 	if _, ok := files[manifest.Entry]; !ok {
 		return nil, fmt.Errorf("entry file %q referenced by manifest not found in ConfigMap", manifest.Entry)
 	}
-	if manifest.Route != nil {
-		if manifest.Route.Path == "" {
-			return nil, fmt.Errorf("manifest is missing 'route.path'")
-		}
-		if manifest.Route.SidebarLabel == "" {
-			return nil, fmt.Errorf("manifest is missing 'route.sidebarLabel'")
-		}
-		// See PluginRoute's doc: there's currently nothing else that can supply what the host
-		// mounts at Route.Path.
-		if manifest.Federation == nil {
-			return nil, fmt.Errorf("manifest's 'route' requires 'federation'")
-		}
-		// The one reservation the backend can enforce on Route.Path itself - "api/" is its own
-		// reserved prefix (see GetPluginFile), not something specific to any one frontend. A
-		// route colliding with a given host's own built-in pages (e.g. "/settings") is instead
-		// the host's job to reject, the same way it already does for code-registered routes
-		// (see plugins.ts's RESERVED_PATHS/dedupeByPath in either frontend) - the backend has no
-		// way to know a given host's built-in path list.
-		if trimmed := strings.TrimPrefix(manifest.Route.Path, "/"); strings.HasPrefix(trimmed, "api/") {
-			return nil, fmt.Errorf("manifest's 'route.path' %q falls under the reserved 'api/' prefix", manifest.Route.Path)
-		}
+	// See PluginRoute's doc: there's currently nothing else that can supply what the host mounts
+	// at any of Routes' Paths.
+	if len(manifest.Routes) > 0 && manifest.Federation == nil {
+		return nil, fmt.Errorf("manifest's 'routes' requires 'federation'")
 	}
 	if manifest.Federation != nil {
 		if manifest.Federation.RemoteEntry == "" {
 			return nil, fmt.Errorf("manifest's federation is missing 'remoteEntry'")
 		}
-		if manifest.Federation.ExposedModule == "" {
-			return nil, fmt.Errorf("manifest's federation is missing 'exposedModule'")
-		}
 		if _, ok := files[manifest.Federation.RemoteEntry]; !ok {
 			return nil, fmt.Errorf("remote entry file %q referenced by manifest's federation not found in ConfigMap", manifest.Federation.RemoteEntry)
 		}
+	}
+	seenPaths := make(map[string]bool, len(manifest.Routes))
+	for i, route := range manifest.Routes {
+		if route.Path == "" {
+			return nil, fmt.Errorf("manifest's 'routes[%d]' is missing 'path'", i)
+		}
+		if route.SidebarLabel == "" {
+			return nil, fmt.Errorf("manifest's 'routes[%d]' is missing 'sidebarLabel'", i)
+		}
+		if route.ExposedModule == "" {
+			return nil, fmt.Errorf("manifest's 'routes[%d]' is missing 'exposedModule'", i)
+		}
+		// The one reservation the backend can enforce on a route's Path itself - "api/" is its
+		// own reserved prefix (see GetPluginFile), not something specific to any one frontend. A
+		// route colliding with a given host's own built-in pages (e.g. "/settings") is instead
+		// the host's job to reject, the same way it already does for code-registered routes (see
+		// plugins.ts's RESERVED_PATHS/dedupeByPath in either frontend) - the backend has no way
+		// to know a given host's built-in path list.
+		if trimmed := strings.TrimPrefix(route.Path, "/"); strings.HasPrefix(trimmed, "api/") {
+			return nil, fmt.Errorf("manifest's 'routes[%d].path' %q falls under the reserved 'api/' prefix", i, route.Path)
+		}
+		if seenPaths[route.Path] {
+			return nil, fmt.Errorf("manifest's 'routes[%d].path' %q duplicates an earlier route in the same manifest", i, route.Path)
+		}
+		seenPaths[route.Path] = true
 	}
 	return &pluginEntry{manifest: manifest, files: files}, nil
 }

--- a/pkg/plugins/registry.go
+++ b/pkg/plugins/registry.go
@@ -159,7 +159,10 @@ func parsePluginConfigMap(cm *corev1.ConfigMap) (*pluginEntry, error) {
 		if _, ok := files[manifest.Federation.RemoteEntry]; !ok {
 			return nil, fmt.Errorf("remote entry file %q referenced by manifest's federation not found in ConfigMap", manifest.Federation.RemoteEntry)
 		}
-		seenPaths := make(map[string]bool, len(manifest.Federation.Routes))
+		if len(manifest.Federation.Routes) == 0 {
+			return nil, fmt.Errorf("manifest's 'federation.routes' must not be empty")
+		}
+		seenPaths := make(map[string]string, len(manifest.Federation.Routes))
 		for i, route := range manifest.Federation.Routes {
 			if route.Path == "" {
 				return nil, fmt.Errorf("manifest's 'federation.routes[%d]' is missing 'path'", i)
@@ -174,15 +177,18 @@ func parsePluginConfigMap(cm *corev1.ConfigMap) (*pluginEntry, error) {
 			// its own reserved prefix (see GetPluginFile), not something specific to any one
 			// frontend. A route colliding with a given host's own built-in pages (e.g.
 			// "/settings") is instead the host's job to reject, the same way it already does for
-			// code-registered routes (see plugins.ts's RESERVED_PATHS/dedupeByPath in either
-			// frontend) - the backend has no way to know a given host's built-in path list.
-			if trimmed := strings.TrimPrefix(route.Path, "/"); strings.HasPrefix(trimmed, "api/") {
+			// code-registered routes (see plugins.ts's RESERVED_PATHS/dedupeByPath in the
+			// out-of-tree, module-federation-aware host - Antrea UI's own frontend ignores
+			// 'federation' altogether) - the backend has no way to know a given host's built-in
+			// path list.
+			trimmed := strings.TrimPrefix(route.Path, "/")
+			if strings.HasPrefix(trimmed, "api/") {
 				return nil, fmt.Errorf("manifest's 'federation.routes[%d].path' %q falls under the reserved 'api/' prefix", i, route.Path)
 			}
-			if seenPaths[route.Path] {
-				return nil, fmt.Errorf("manifest's 'federation.routes[%d].path' %q duplicates an earlier route in the same manifest", i, route.Path)
+			if other, ok := seenPaths[trimmed]; ok {
+				return nil, fmt.Errorf("manifest's 'federation.routes[%d].path' %q duplicates earlier route %q in the same manifest", i, route.Path, other)
 			}
-			seenPaths[route.Path] = true
+			seenPaths[trimmed] = route.Path
 		}
 	}
 	return &pluginEntry{manifest: manifest, files: files}, nil

--- a/pkg/plugins/registry.go
+++ b/pkg/plugins/registry.go
@@ -154,8 +154,16 @@ func parsePluginConfigMap(cm *corev1.ConfigMap) (*pluginEntry, error) {
 	if manifest.Route != nil && manifest.Route.Path == "" {
 		return nil, fmt.Errorf("manifest's route is missing 'path'")
 	}
-	if manifest.Federation != nil && manifest.Federation.ExposedModule == "" {
-		return nil, fmt.Errorf("manifest's federation is missing 'exposedModule'")
+	if manifest.Federation != nil {
+		if manifest.Federation.RemoteEntry == "" {
+			return nil, fmt.Errorf("manifest's federation is missing 'remoteEntry'")
+		}
+		if manifest.Federation.ExposedModule == "" {
+			return nil, fmt.Errorf("manifest's federation is missing 'exposedModule'")
+		}
+		if _, ok := files[manifest.Federation.RemoteEntry]; !ok {
+			return nil, fmt.Errorf("remote entry file %q referenced by manifest's federation not found in ConfigMap", manifest.Federation.RemoteEntry)
+		}
 	}
 	return &pluginEntry{manifest: manifest, files: files}, nil
 }

--- a/pkg/plugins/registry_test.go
+++ b/pkg/plugins/registry_test.go
@@ -103,6 +103,20 @@ func TestRegistrySkipsInvalidConfigMaps(t *testing.T) {
 		"missing name":           configMap("cm", "", "0.1.0", "index.js", map[string]string{"index.js": "x"}),
 		"missing entry":          configMap("cm", "plugin", "0.1.0", "", map[string]string{"index.js": "x"}),
 		"entry file not present": configMap("cm", "plugin", "0.1.0", "index.js", nil),
+		"route missing path": {
+			ObjectMeta: metav1.ObjectMeta{Name: "cm"},
+			Data: map[string]string{
+				"manifest.json": `{"name":"plugin","version":"0.1.0","entry":"index.js","route":{"sidebarLabel":"Plugin"}}`,
+				"index.js":      "x",
+			},
+		},
+		"federation missing exposedModule": {
+			ObjectMeta: metav1.ObjectMeta{Name: "cm"},
+			Data: map[string]string{
+				"manifest.json":    `{"name":"plugin","version":"0.1.0","entry":"remoteEntry.json","federation":{}}`,
+				"remoteEntry.json": "x",
+			},
+		},
 	}
 	for name, cm := range cases {
 		t.Run(name, func(t *testing.T) {
@@ -111,6 +125,36 @@ func TestRegistrySkipsInvalidConfigMaps(t *testing.T) {
 			assert.Empty(t, r.Index())
 		})
 	}
+}
+
+func TestRegistryIndexIncludesRouteAndFederation(t *testing.T) {
+	r := newTestRegistry(t)
+
+	r.handleUpsert(&corev1.ConfigMap{
+		ObjectMeta: metav1.ObjectMeta{Name: "policy-management-plugin", Namespace: "antrea-ui"},
+		Data: map[string]string{
+			"manifest.json": `{
+				"name": "policy-management",
+				"version": "0.2.0",
+				"entry": "remoteEntry.json",
+				"route": {"path": "/policy-management", "sidebarLabel": "Policy Management", "icon": "M0 0h16v16H0z"},
+				"federation": {"exposedModule": "./PolicyManagementPage"}
+			}`,
+			"remoteEntry.json": "{}",
+		},
+	})
+
+	assert.Equal(t, []apisv1.PluginManifest{{
+		Name:    "policy-management",
+		Version: "0.2.0",
+		Entry:   "remoteEntry.json",
+		Route: &apisv1.PluginRoute{
+			Path:         "/policy-management",
+			SidebarLabel: "Policy Management",
+			Icon:         "M0 0h16v16H0z",
+		},
+		Federation: &apisv1.PluginFederation{ExposedModule: "./PolicyManagementPage"},
+	}}, r.Index())
 }
 
 func TestRegistryDuplicatePluginNameKeepsLowerConfigMapName(t *testing.T) {

--- a/pkg/plugins/registry_test.go
+++ b/pkg/plugins/registry_test.go
@@ -19,6 +19,7 @@ import (
 
 	"github.com/go-logr/logr/testr"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
@@ -91,105 +92,179 @@ func TestRegistryUpdateReplacesPreviousContents(t *testing.T) {
 }
 
 func TestRegistrySkipsInvalidConfigMaps(t *testing.T) {
-	cases := map[string]*corev1.ConfigMap{
+	cases := map[string]struct {
+		cm      *corev1.ConfigMap
+		wantErr string
+	}{
 		"missing manifest.json": {
-			ObjectMeta: metav1.ObjectMeta{Name: "cm"},
-			Data:       map[string]string{"index.js": "x"},
+			cm:      &corev1.ConfigMap{ObjectMeta: metav1.ObjectMeta{Name: "cm"}, Data: map[string]string{"index.js": "x"}},
+			wantErr: "missing manifest.json",
 		},
 		"malformed manifest.json": {
-			ObjectMeta: metav1.ObjectMeta{Name: "cm"},
-			Data:       map[string]string{"manifest.json": "not json"},
+			cm:      &corev1.ConfigMap{ObjectMeta: metav1.ObjectMeta{Name: "cm"}, Data: map[string]string{"manifest.json": "not json"}},
+			wantErr: "invalid manifest.json",
 		},
-		"missing name":           configMap("cm", "", "0.1.0", "index.js", map[string]string{"index.js": "x"}),
-		"missing entry":          configMap("cm", "plugin", "0.1.0", "", map[string]string{"index.js": "x"}),
-		"entry file not present": configMap("cm", "plugin", "0.1.0", "index.js", nil),
+		"missing name": {
+			cm:      configMap("cm", "", "0.1.0", "index.js", map[string]string{"index.js": "x"}),
+			wantErr: "manifest is missing 'name'",
+		},
+		"missing entry": {
+			cm:      configMap("cm", "plugin", "0.1.0", "", map[string]string{"index.js": "x"}),
+			wantErr: "manifest is missing 'entry'",
+		},
+		"entry file not present": {
+			cm:      configMap("cm", "plugin", "0.1.0", "index.js", nil),
+			wantErr: "entry file \"index.js\" referenced by manifest not found",
+		},
 		"route missing path": {
-			ObjectMeta: metav1.ObjectMeta{Name: "cm"},
-			Data: map[string]string{
-				"manifest.json":    `{"name":"plugin","version":"0.1.0","entry":"index.js","federation":{"remoteEntry":"remoteEntry.json","routes":[{"sidebarLabel":"Plugin","exposedModule":"./Page"}]}}`,
-				"index.js":         "x",
-				"remoteEntry.json": "x",
+			cm: &corev1.ConfigMap{
+				ObjectMeta: metav1.ObjectMeta{Name: "cm"},
+				Data: map[string]string{
+					"manifest.json":    `{"name":"plugin","version":"0.1.0","entry":"index.js","federation":{"remoteEntry":"remoteEntry.json","routes":[{"sidebarLabel":"Plugin","exposedModule":"./Page"}]}}`,
+					"index.js":         "x",
+					"remoteEntry.json": "x",
+				},
 			},
+			wantErr: "'federation.routes[0]' is missing 'path'",
 		},
 		"route missing sidebarLabel": {
-			ObjectMeta: metav1.ObjectMeta{Name: "cm"},
-			Data: map[string]string{
-				"manifest.json":    `{"name":"plugin","version":"0.1.0","entry":"index.js","federation":{"remoteEntry":"remoteEntry.json","routes":[{"path":"/plugin","exposedModule":"./Page"}]}}`,
-				"index.js":         "x",
-				"remoteEntry.json": "x",
+			cm: &corev1.ConfigMap{
+				ObjectMeta: metav1.ObjectMeta{Name: "cm"},
+				Data: map[string]string{
+					"manifest.json":    `{"name":"plugin","version":"0.1.0","entry":"index.js","federation":{"remoteEntry":"remoteEntry.json","routes":[{"path":"/plugin","exposedModule":"./Page"}]}}`,
+					"index.js":         "x",
+					"remoteEntry.json": "x",
+				},
 			},
+			wantErr: "'federation.routes[0]' is missing 'sidebarLabel'",
 		},
 		"route missing exposedModule": {
-			ObjectMeta: metav1.ObjectMeta{Name: "cm"},
-			Data: map[string]string{
-				"manifest.json":    `{"name":"plugin","version":"0.1.0","entry":"index.js","federation":{"remoteEntry":"remoteEntry.json","routes":[{"path":"/plugin","sidebarLabel":"Plugin"}]}}`,
-				"index.js":         "x",
-				"remoteEntry.json": "x",
+			cm: &corev1.ConfigMap{
+				ObjectMeta: metav1.ObjectMeta{Name: "cm"},
+				Data: map[string]string{
+					"manifest.json":    `{"name":"plugin","version":"0.1.0","entry":"index.js","federation":{"remoteEntry":"remoteEntry.json","routes":[{"path":"/plugin","sidebarLabel":"Plugin"}]}}`,
+					"index.js":         "x",
+					"remoteEntry.json": "x",
+				},
 			},
+			wantErr: "'federation.routes[0]' is missing 'exposedModule'",
 		},
-		"route path under reserved api/ prefix": {
-			ObjectMeta: metav1.ObjectMeta{Name: "cm"},
-			Data: map[string]string{
-				"manifest.json":    `{"name":"plugin","version":"0.1.0","entry":"index.js","federation":{"remoteEntry":"remoteEntry.json","routes":[{"path":"/api/v1/plugin","sidebarLabel":"Plugin","exposedModule":"./Page"}]}}`,
-				"index.js":         "x",
-				"remoteEntry.json": "x",
+		"route path under reserved api prefix": {
+			cm: &corev1.ConfigMap{
+				ObjectMeta: metav1.ObjectMeta{Name: "cm"},
+				Data: map[string]string{
+					"manifest.json":    `{"name":"plugin","version":"0.1.0","entry":"index.js","federation":{"remoteEntry":"remoteEntry.json","routes":[{"path":"/apiobjects","sidebarLabel":"Plugin","exposedModule":"./Page"}]}}`,
+					"index.js":         "x",
+					"remoteEntry.json": "x",
+				},
 			},
+			wantErr: "'federation.routes[0].path' \"/apiobjects\" falls under a reserved prefix",
+		},
+		"route path under reserved auth prefix": {
+			cm: &corev1.ConfigMap{
+				ObjectMeta: metav1.ObjectMeta{Name: "cm"},
+				Data: map[string]string{
+					"manifest.json":    `{"name":"plugin","version":"0.1.0","entry":"index.js","federation":{"remoteEntry":"remoteEntry.json","routes":[{"path":"/authors","sidebarLabel":"Plugin","exposedModule":"./Page"}]}}`,
+					"index.js":         "x",
+					"remoteEntry.json": "x",
+				},
+			},
+			wantErr: "'federation.routes[0].path' \"/authors\" falls under a reserved prefix",
 		},
 		"duplicate route path in the same manifest": {
-			ObjectMeta: metav1.ObjectMeta{Name: "cm"},
-			Data: map[string]string{
-				"manifest.json": `{"name":"plugin","version":"0.1.0","entry":"index.js","federation":{"remoteEntry":"remoteEntry.json","routes":[
-					{"path":"/plugin","sidebarLabel":"Plugin","exposedModule":"./Page"},
-					{"path":"/plugin","sidebarLabel":"Plugin Again","exposedModule":"./OtherPage"}
-				]}}`,
-				"index.js":         "x",
-				"remoteEntry.json": "x",
+			cm: &corev1.ConfigMap{
+				ObjectMeta: metav1.ObjectMeta{Name: "cm"},
+				Data: map[string]string{
+					"manifest.json": `{"name":"plugin","version":"0.1.0","entry":"index.js","federation":{"remoteEntry":"remoteEntry.json","routes":[
+						{"path":"/plugin","sidebarLabel":"Plugin","exposedModule":"./Page"},
+						{"path":"/plugin","sidebarLabel":"Plugin Again","exposedModule":"./OtherPage"}
+					]}}`,
+					"index.js":         "x",
+					"remoteEntry.json": "x",
+				},
 			},
+			wantErr: "'federation.routes[1].path' \"/plugin\" duplicates earlier route \"/plugin\"",
 		},
 		"duplicate route path differing only by leading slash": {
-			ObjectMeta: metav1.ObjectMeta{Name: "cm"},
-			Data: map[string]string{
-				"manifest.json": `{"name":"plugin","version":"0.1.0","entry":"index.js","federation":{"remoteEntry":"remoteEntry.json","routes":[
-					{"path":"/plugin","sidebarLabel":"Plugin","exposedModule":"./Page"},
-					{"path":"plugin","sidebarLabel":"Plugin Again","exposedModule":"./OtherPage"}
-				]}}`,
-				"index.js":         "x",
-				"remoteEntry.json": "x",
+			cm: &corev1.ConfigMap{
+				ObjectMeta: metav1.ObjectMeta{Name: "cm"},
+				Data: map[string]string{
+					"manifest.json": `{"name":"plugin","version":"0.1.0","entry":"index.js","federation":{"remoteEntry":"remoteEntry.json","routes":[
+						{"path":"/plugin","sidebarLabel":"Plugin","exposedModule":"./Page"},
+						{"path":"plugin","sidebarLabel":"Plugin Again","exposedModule":"./OtherPage"}
+					]}}`,
+					"index.js":         "x",
+					"remoteEntry.json": "x",
+				},
 			},
+			wantErr: "'federation.routes[1].path' \"plugin\" duplicates earlier route \"/plugin\"",
+		},
+		"duplicate route path differing only by doubled and trailing slashes": {
+			cm: &corev1.ConfigMap{
+				ObjectMeta: metav1.ObjectMeta{Name: "cm"},
+				Data: map[string]string{
+					"manifest.json": `{"name":"plugin","version":"0.1.0","entry":"index.js","federation":{"remoteEntry":"remoteEntry.json","routes":[
+						{"path":"/plugin","sidebarLabel":"Plugin","exposedModule":"./Page"},
+						{"path":"//plugin/","sidebarLabel":"Plugin Again","exposedModule":"./OtherPage"}
+					]}}`,
+					"index.js":         "x",
+					"remoteEntry.json": "x",
+				},
+			},
+			wantErr: "'federation.routes[1].path' \"//plugin/\" duplicates earlier route \"/plugin\"",
 		},
 		"federation with no routes": {
-			ObjectMeta: metav1.ObjectMeta{Name: "cm"},
-			Data: map[string]string{
-				"manifest.json":    `{"name":"plugin","version":"0.1.0","entry":"index.js","federation":{"remoteEntry":"remoteEntry.json","routes":[]}}`,
-				"index.js":         "x",
-				"remoteEntry.json": "x",
+			cm: &corev1.ConfigMap{
+				ObjectMeta: metav1.ObjectMeta{Name: "cm"},
+				Data: map[string]string{
+					"manifest.json":    `{"name":"plugin","version":"0.1.0","entry":"index.js","federation":{"remoteEntry":"remoteEntry.json","routes":[]}}`,
+					"index.js":         "x",
+					"remoteEntry.json": "x",
+				},
 			},
+			wantErr: "'federation.routes' must not be empty",
 		},
 		"federation missing remoteEntry": {
-			ObjectMeta: metav1.ObjectMeta{Name: "cm"},
-			Data: map[string]string{
-				"manifest.json": `{"name":"plugin","version":"0.1.0","entry":"index.js","federation":{}}`,
-				"index.js":      "x",
+			cm: &corev1.ConfigMap{
+				ObjectMeta: metav1.ObjectMeta{Name: "cm"},
+				Data: map[string]string{
+					"manifest.json": `{"name":"plugin","version":"0.1.0","entry":"index.js","federation":{}}`,
+					"index.js":      "x",
+				},
 			},
+			wantErr: "federation is missing 'remoteEntry'",
+		},
+		"federation remoteEntry same file as entry": {
+			cm: &corev1.ConfigMap{
+				ObjectMeta: metav1.ObjectMeta{Name: "cm"},
+				Data: map[string]string{
+					"manifest.json": `{"name":"plugin","version":"0.1.0","entry":"shared.js","federation":{"remoteEntry":"shared.js","routes":[{"path":"/plugin","sidebarLabel":"Plugin","exposedModule":"./Page"}]}}`,
+					"shared.js":     "x",
+				},
+			},
+			wantErr: "'federation.remoteEntry' must not be the same file as 'entry'",
 		},
 		"federation remoteEntry file not present": {
-			ObjectMeta: metav1.ObjectMeta{Name: "cm"},
-			Data: map[string]string{
-				"manifest.json": `{"name":"plugin","version":"0.1.0","entry":"index.js","federation":{"remoteEntry":"remoteEntry.json","routes":[{"path":"/plugin","sidebarLabel":"Plugin","exposedModule":"./Page"}]}}`,
-				"index.js":      "x",
+			cm: &corev1.ConfigMap{
+				ObjectMeta: metav1.ObjectMeta{Name: "cm"},
+				Data: map[string]string{
+					"manifest.json": `{"name":"plugin","version":"0.1.0","entry":"index.js","federation":{"remoteEntry":"remoteEntry.json","routes":[{"path":"/plugin","sidebarLabel":"Plugin","exposedModule":"./Page"}]}}`,
+					"index.js":      "x",
+				},
 			},
+			wantErr: "remote entry file \"remoteEntry.json\" referenced by manifest's federation not found",
 		},
 	}
-	for name, cm := range cases {
+	for name, tc := range cases {
 		t.Run(name, func(t *testing.T) {
-			r := newTestRegistry(t)
-			r.handleUpsert(cm)
-			assert.Empty(t, r.Index())
+			_, err := parsePluginConfigMap(tc.cm)
+			require.Error(t, err)
+			assert.Contains(t, err.Error(), tc.wantErr)
 		})
 	}
 }
 
-func TestRegistryIndexIncludesRoutesAndFederation(t *testing.T) {
+func TestRegistryIndexIncludesFederation(t *testing.T) {
 	r := newTestRegistry(t)
 
 	r.handleUpsert(&corev1.ConfigMap{
@@ -224,6 +299,36 @@ func TestRegistryIndexIncludesRoutesAndFederation(t *testing.T) {
 			},
 		},
 	}}, r.Index())
+}
+
+func TestRegistryIndexDropsFederationRoutePathCollidingWithAnotherPlugin(t *testing.T) {
+	r := newTestRegistry(t)
+
+	manifest := func(cmName string) *corev1.ConfigMap {
+		return &corev1.ConfigMap{
+			ObjectMeta: metav1.ObjectMeta{Name: cmName, Namespace: "antrea-ui"},
+			Data: map[string]string{
+				"manifest.json": `{
+					"name": "` + cmName + `-plugin",
+					"version": "0.1.0",
+					"entry": "index.js",
+					"federation": {
+						"remoteEntry": "remoteEntry.json",
+						"routes": [{"path": "/policies", "sidebarLabel": "Policies", "exposedModule": "./Page"}]
+					}
+				}`,
+				"index.js":         "x",
+				"remoteEntry.json": "x",
+			},
+		}
+	}
+
+	r.handleUpsert(manifest("b-configmap"))
+	r.handleUpsert(manifest("a-configmap"))
+
+	manifests := r.Index()
+	require.Len(t, manifests, 1)
+	assert.Equal(t, "a-configmap-plugin", manifests[0].Name)
 }
 
 func TestRegistryDuplicatePluginNameKeepsLowerConfigMapName(t *testing.T) {

--- a/pkg/plugins/registry_test.go
+++ b/pkg/plugins/registry_test.go
@@ -110,11 +110,26 @@ func TestRegistrySkipsInvalidConfigMaps(t *testing.T) {
 				"index.js":      "x",
 			},
 		},
+		"federation missing remoteEntry": {
+			ObjectMeta: metav1.ObjectMeta{Name: "cm"},
+			Data: map[string]string{
+				"manifest.json": `{"name":"plugin","version":"0.1.0","entry":"index.js","federation":{"exposedModule":"./Page"}}`,
+				"index.js":      "x",
+			},
+		},
 		"federation missing exposedModule": {
 			ObjectMeta: metav1.ObjectMeta{Name: "cm"},
 			Data: map[string]string{
-				"manifest.json":    `{"name":"plugin","version":"0.1.0","entry":"remoteEntry.json","federation":{}}`,
+				"manifest.json":    `{"name":"plugin","version":"0.1.0","entry":"index.js","federation":{"remoteEntry":"remoteEntry.json"}}`,
+				"index.js":         "x",
 				"remoteEntry.json": "x",
+			},
+		},
+		"federation remoteEntry file not present": {
+			ObjectMeta: metav1.ObjectMeta{Name: "cm"},
+			Data: map[string]string{
+				"manifest.json": `{"name":"plugin","version":"0.1.0","entry":"index.js","federation":{"remoteEntry":"remoteEntry.json","exposedModule":"./Page"}}`,
+				"index.js":      "x",
 			},
 		},
 	}
@@ -136,10 +151,11 @@ func TestRegistryIndexIncludesRouteAndFederation(t *testing.T) {
 			"manifest.json": `{
 				"name": "policy-management",
 				"version": "0.2.0",
-				"entry": "remoteEntry.json",
-				"route": {"path": "/policy-management", "sidebarLabel": "Policy Management", "icon": "M0 0h16v16H0z"},
-				"federation": {"exposedModule": "./PolicyManagementPage"}
+				"entry": "index.js",
+				"route": {"path": "/policies", "sidebarLabel": "Policy Management", "icon": "M0 0h16v16H0z"},
+				"federation": {"remoteEntry": "remoteEntry.json", "exposedModule": "./PolicyManagementPage"}
 			}`,
+			"index.js":         "x",
 			"remoteEntry.json": "{}",
 		},
 	})
@@ -147,13 +163,13 @@ func TestRegistryIndexIncludesRouteAndFederation(t *testing.T) {
 	assert.Equal(t, []apisv1.PluginManifest{{
 		Name:    "policy-management",
 		Version: "0.2.0",
-		Entry:   "remoteEntry.json",
+		Entry:   "index.js",
 		Route: &apisv1.PluginRoute{
-			Path:         "/policy-management",
+			Path:         "/policies",
 			SidebarLabel: "Policy Management",
 			Icon:         "M0 0h16v16H0z",
 		},
-		Federation: &apisv1.PluginFederation{ExposedModule: "./PolicyManagementPage"},
+		Federation: &apisv1.PluginFederation{RemoteEntry: "remoteEntry.json", ExposedModule: "./PolicyManagementPage"},
 	}}, r.Index())
 }
 

--- a/pkg/plugins/registry_test.go
+++ b/pkg/plugins/registry_test.go
@@ -106,7 +106,7 @@ func TestRegistrySkipsInvalidConfigMaps(t *testing.T) {
 		"route missing path": {
 			ObjectMeta: metav1.ObjectMeta{Name: "cm"},
 			Data: map[string]string{
-				"manifest.json":    `{"name":"plugin","version":"0.1.0","entry":"index.js","routes":[{"sidebarLabel":"Plugin","exposedModule":"./Page"}],"federation":{"remoteEntry":"remoteEntry.json"}}`,
+				"manifest.json":    `{"name":"plugin","version":"0.1.0","entry":"index.js","federation":{"remoteEntry":"remoteEntry.json","routes":[{"sidebarLabel":"Plugin","exposedModule":"./Page"}]}}`,
 				"index.js":         "x",
 				"remoteEntry.json": "x",
 			},
@@ -114,7 +114,7 @@ func TestRegistrySkipsInvalidConfigMaps(t *testing.T) {
 		"route missing sidebarLabel": {
 			ObjectMeta: metav1.ObjectMeta{Name: "cm"},
 			Data: map[string]string{
-				"manifest.json":    `{"name":"plugin","version":"0.1.0","entry":"index.js","routes":[{"path":"/plugin","exposedModule":"./Page"}],"federation":{"remoteEntry":"remoteEntry.json"}}`,
+				"manifest.json":    `{"name":"plugin","version":"0.1.0","entry":"index.js","federation":{"remoteEntry":"remoteEntry.json","routes":[{"path":"/plugin","exposedModule":"./Page"}]}}`,
 				"index.js":         "x",
 				"remoteEntry.json": "x",
 			},
@@ -122,22 +122,15 @@ func TestRegistrySkipsInvalidConfigMaps(t *testing.T) {
 		"route missing exposedModule": {
 			ObjectMeta: metav1.ObjectMeta{Name: "cm"},
 			Data: map[string]string{
-				"manifest.json":    `{"name":"plugin","version":"0.1.0","entry":"index.js","routes":[{"path":"/plugin","sidebarLabel":"Plugin"}],"federation":{"remoteEntry":"remoteEntry.json"}}`,
+				"manifest.json":    `{"name":"plugin","version":"0.1.0","entry":"index.js","federation":{"remoteEntry":"remoteEntry.json","routes":[{"path":"/plugin","sidebarLabel":"Plugin"}]}}`,
 				"index.js":         "x",
 				"remoteEntry.json": "x",
-			},
-		},
-		"route without federation": {
-			ObjectMeta: metav1.ObjectMeta{Name: "cm"},
-			Data: map[string]string{
-				"manifest.json": `{"name":"plugin","version":"0.1.0","entry":"index.js","routes":[{"path":"/plugin","sidebarLabel":"Plugin","exposedModule":"./Page"}]}`,
-				"index.js":      "x",
 			},
 		},
 		"route path under reserved api/ prefix": {
 			ObjectMeta: metav1.ObjectMeta{Name: "cm"},
 			Data: map[string]string{
-				"manifest.json":    `{"name":"plugin","version":"0.1.0","entry":"index.js","routes":[{"path":"/api/v1/plugin","sidebarLabel":"Plugin","exposedModule":"./Page"}],"federation":{"remoteEntry":"remoteEntry.json"}}`,
+				"manifest.json":    `{"name":"plugin","version":"0.1.0","entry":"index.js","federation":{"remoteEntry":"remoteEntry.json","routes":[{"path":"/api/v1/plugin","sidebarLabel":"Plugin","exposedModule":"./Page"}]}}`,
 				"index.js":         "x",
 				"remoteEntry.json": "x",
 			},
@@ -145,10 +138,10 @@ func TestRegistrySkipsInvalidConfigMaps(t *testing.T) {
 		"duplicate route path in the same manifest": {
 			ObjectMeta: metav1.ObjectMeta{Name: "cm"},
 			Data: map[string]string{
-				"manifest.json": `{"name":"plugin","version":"0.1.0","entry":"index.js","routes":[
+				"manifest.json": `{"name":"plugin","version":"0.1.0","entry":"index.js","federation":{"remoteEntry":"remoteEntry.json","routes":[
 					{"path":"/plugin","sidebarLabel":"Plugin","exposedModule":"./Page"},
 					{"path":"/plugin","sidebarLabel":"Plugin Again","exposedModule":"./OtherPage"}
-				],"federation":{"remoteEntry":"remoteEntry.json"}}`,
+				]}}`,
 				"index.js":         "x",
 				"remoteEntry.json": "x",
 			},
@@ -187,11 +180,13 @@ func TestRegistryIndexIncludesRoutesAndFederation(t *testing.T) {
 				"name": "policy-management",
 				"version": "0.2.0",
 				"entry": "index.js",
-				"routes": [
-					{"path": "/policies", "sidebarLabel": "Policy Management", "icon": "M0 0h16v16H0z", "exposedModule": "./PolicyManagementPage"},
-					{"path": "/policies/audit", "sidebarLabel": "Policy Audit Log", "exposedModule": "./PolicyAuditPage"}
-				],
-				"federation": {"remoteEntry": "remoteEntry.json"}
+				"federation": {
+					"remoteEntry": "remoteEntry.json",
+					"routes": [
+						{"path": "/policies", "sidebarLabel": "Policy Management", "icon": "M0 0h16v16H0z", "exposedModule": "./PolicyManagementPage"},
+						{"path": "/policies/audit", "sidebarLabel": "Policy Audit Log", "exposedModule": "./PolicyAuditPage"}
+					]
+				}
 			}`,
 			"index.js":         "x",
 			"remoteEntry.json": "{}",
@@ -202,11 +197,13 @@ func TestRegistryIndexIncludesRoutesAndFederation(t *testing.T) {
 		Name:    "policy-management",
 		Version: "0.2.0",
 		Entry:   "index.js",
-		Routes: []apisv1.PluginRoute{
-			{Path: "/policies", SidebarLabel: "Policy Management", Icon: "M0 0h16v16H0z", ExposedModule: "./PolicyManagementPage"},
-			{Path: "/policies/audit", SidebarLabel: "Policy Audit Log", ExposedModule: "./PolicyAuditPage"},
+		Federation: &apisv1.PluginFederation{
+			RemoteEntry: "remoteEntry.json",
+			Routes: []apisv1.PluginRoute{
+				{Path: "/policies", SidebarLabel: "Policy Management", Icon: "M0 0h16v16H0z", ExposedModule: "./PolicyManagementPage"},
+				{Path: "/policies/audit", SidebarLabel: "Policy Audit Log", ExposedModule: "./PolicyAuditPage"},
+			},
 		},
-		Federation: &apisv1.PluginFederation{RemoteEntry: "remoteEntry.json"},
 	}}, r.Index())
 }
 

--- a/pkg/plugins/registry_test.go
+++ b/pkg/plugins/registry_test.go
@@ -158,7 +158,7 @@ func TestRegistrySkipsInvalidConfigMaps(t *testing.T) {
 					"remoteEntry.json": "x",
 				},
 			},
-			wantErr: "'federation.routes[0].path' \"/apiobjects\" falls under a reserved prefix",
+			wantErr: "'federation.routes[0].path' \"/apiobjects\" is the root path or falls under a reserved prefix",
 		},
 		"route path under reserved auth prefix": {
 			cm: &corev1.ConfigMap{
@@ -169,7 +169,29 @@ func TestRegistrySkipsInvalidConfigMaps(t *testing.T) {
 					"remoteEntry.json": "x",
 				},
 			},
-			wantErr: "'federation.routes[0].path' \"/authors\" falls under a reserved prefix",
+			wantErr: "'federation.routes[0].path' \"/authors\" is the root path or falls under a reserved prefix",
+		},
+		"route path is the root path": {
+			cm: &corev1.ConfigMap{
+				ObjectMeta: metav1.ObjectMeta{Name: "cm"},
+				Data: map[string]string{
+					"manifest.json":    `{"name":"plugin","version":"0.1.0","entry":"index.js","federation":{"remoteEntry":"remoteEntry.json","routes":[{"path":"/","sidebarLabel":"Plugin","exposedModule":"./Page"}]}}`,
+					"index.js":         "x",
+					"remoteEntry.json": "x",
+				},
+			},
+			wantErr: "'federation.routes[0].path' \"/\" is the root path or falls under a reserved prefix",
+		},
+		"route path collapses to the root path via dot segments": {
+			cm: &corev1.ConfigMap{
+				ObjectMeta: metav1.ObjectMeta{Name: "cm"},
+				Data: map[string]string{
+					"manifest.json":    `{"name":"plugin","version":"0.1.0","entry":"index.js","federation":{"remoteEntry":"remoteEntry.json","routes":[{"path":"/plugin/..","sidebarLabel":"Plugin","exposedModule":"./Page"}]}}`,
+					"index.js":         "x",
+					"remoteEntry.json": "x",
+				},
+			},
+			wantErr: "'federation.routes[0].path' \"/plugin/..\" is the root path or falls under a reserved prefix",
 		},
 		"duplicate route path in the same manifest": {
 			cm: &corev1.ConfigMap{
@@ -264,6 +286,18 @@ func TestRegistrySkipsInvalidConfigMaps(t *testing.T) {
 	}
 }
 
+// TestRegistryHandleUpsertSkipsInvalidConfigMap exercises handleUpsert's own
+// error handling (parsePluginConfigMap's error cases are covered directly,
+// by message, in TestRegistrySkipsInvalidConfigMaps).
+func TestRegistryHandleUpsertSkipsInvalidConfigMap(t *testing.T) {
+	r := newTestRegistry(t)
+	r.handleUpsert(&corev1.ConfigMap{
+		ObjectMeta: metav1.ObjectMeta{Name: "cm"},
+		Data:       map[string]string{"manifest.json": "not json"},
+	})
+	assert.Empty(t, r.Index())
+}
+
 func TestRegistryIndexIncludesFederation(t *testing.T) {
 	r := newTestRegistry(t)
 
@@ -301,34 +335,91 @@ func TestRegistryIndexIncludesFederation(t *testing.T) {
 	}}, r.Index())
 }
 
-func TestRegistryIndexDropsFederationRoutePathCollidingWithAnotherPlugin(t *testing.T) {
+func federationConfigMap(cmName, pluginName, entry string, routes string) *corev1.ConfigMap {
+	return &corev1.ConfigMap{
+		ObjectMeta: metav1.ObjectMeta{Name: cmName, Namespace: "antrea-ui"},
+		Data: map[string]string{
+			"manifest.json": `{
+				"name": "` + pluginName + `",
+				"version": "0.1.0",
+				"entry": "` + entry + `",
+				"federation": {"remoteEntry": "remoteEntry.json", "routes": ` + routes + `}
+			}`,
+			entry:              "x",
+			"remoteEntry.json": "x",
+		},
+	}
+}
+
+// TestRegistryIndexDropsPluginWhenAllFederationRoutesCollide pins the
+// cross-plugin path normalization: the two manifests spell the same route
+// path differently ("/policies" vs "//policies/"), so the test would still
+// pass if seenRoutePaths compared raw, un-normalized paths.
+func TestRegistryIndexDropsPluginWhenAllFederationRoutesCollide(t *testing.T) {
 	r := newTestRegistry(t)
 
-	manifest := func(cmName string) *corev1.ConfigMap {
-		return &corev1.ConfigMap{
-			ObjectMeta: metav1.ObjectMeta{Name: cmName, Namespace: "antrea-ui"},
-			Data: map[string]string{
-				"manifest.json": `{
-					"name": "` + cmName + `-plugin",
-					"version": "0.1.0",
-					"entry": "index.js",
-					"federation": {
-						"remoteEntry": "remoteEntry.json",
-						"routes": [{"path": "/policies", "sidebarLabel": "Policies", "exposedModule": "./Page"}]
-					}
-				}`,
-				"index.js":         "x",
-				"remoteEntry.json": "x",
-			},
-		}
-	}
-
-	r.handleUpsert(manifest("b-configmap"))
-	r.handleUpsert(manifest("a-configmap"))
+	r.handleUpsert(federationConfigMap("b-configmap", "b-plugin", "index.js",
+		`[{"path": "//policies/", "sidebarLabel": "Policies", "exposedModule": "./Page"}]`))
+	r.handleUpsert(federationConfigMap("a-configmap", "a-plugin", "index.js",
+		`[{"path": "/policies", "sidebarLabel": "Policies", "exposedModule": "./Page"}]`))
 
 	manifests := r.Index()
 	require.Len(t, manifests, 1)
-	assert.Equal(t, "a-configmap-plugin", manifests[0].Name)
+	assert.Equal(t, "a-plugin", manifests[0].Name)
+}
+
+// TestRegistryIndexFiltersCollidingFederationRouteKeepsRestOfPlugin checks
+// that a route collision drops only the colliding route, not the whole
+// manifest: b-plugin's "entry" and its non-colliding "/other" route stay
+// listed.
+func TestRegistryIndexFiltersCollidingFederationRouteKeepsRestOfPlugin(t *testing.T) {
+	r := newTestRegistry(t)
+
+	r.handleUpsert(federationConfigMap("a-configmap", "a-plugin", "a.js",
+		`[{"path": "/policies", "sidebarLabel": "Policies", "exposedModule": "./Page"}]`))
+	r.handleUpsert(federationConfigMap("b-configmap", "b-plugin", "b.js",
+		`[
+			{"path": "/policies", "sidebarLabel": "Policies Again", "exposedModule": "./OtherPage"},
+			{"path": "/other", "sidebarLabel": "Other", "exposedModule": "./OtherPage"}
+		]`))
+
+	manifests := r.Index()
+	require.Len(t, manifests, 2)
+	assert.Equal(t, "a-plugin", manifests[0].Name)
+	assert.Equal(t, "b-plugin", manifests[1].Name)
+	require.NotNil(t, manifests[1].Federation)
+	assert.Equal(t, []apisv1.PluginRoute{
+		{Path: "/other", SidebarLabel: "Other", ExposedModule: "./OtherPage"},
+	}, manifests[1].Federation.Routes)
+}
+
+// TestRegistryIndexAndFileStayConsistentWhenAllRoutesCollide reproduces the
+// scenario where dropping a whole plugin for an all-routes collision, without
+// claiming its name, let a later ConfigMap reusing that name get listed in
+// Index() with an entry file File() would never actually resolve to (File()
+// always resolves a name to its first-sorted ConfigMap, independently of
+// Index()'s own bookkeeping).
+func TestRegistryIndexAndFileStayConsistentWhenAllRoutesCollide(t *testing.T) {
+	r := newTestRegistry(t)
+
+	r.handleUpsert(federationConfigMap("a-configmap", "aaa", "a.js",
+		`[{"path": "/policies", "sidebarLabel": "Policies", "exposedModule": "./Page"}]`))
+	// b-configmap sorts before c-configmap, and claims the "dup" name first;
+	// its one route collides with aaa's, so the whole manifest is dropped.
+	r.handleUpsert(federationConfigMap("b-configmap", "dup", "b.js",
+		`[{"path": "/policies", "sidebarLabel": "Policies", "exposedModule": "./Page"}]`))
+	r.handleUpsert(federationConfigMap("c-configmap", "dup", "c.js",
+		`[{"path": "/other", "sidebarLabel": "Other", "exposedModule": "./Page"}]`))
+
+	manifests := r.Index()
+	names := make([]string, len(manifests))
+	for i, m := range manifests {
+		names[i] = m.Name
+	}
+	assert.Equal(t, []string{"aaa"}, names, "dup must not be listed at all, from either ConfigMap")
+
+	_, ok := r.File("dup", "c.js")
+	assert.False(t, ok, "c-configmap's entry must never be served for a name Index() doesn't list")
 }
 
 func TestRegistryDuplicatePluginNameKeepsLowerConfigMapName(t *testing.T) {

--- a/pkg/plugins/registry_test.go
+++ b/pkg/plugins/registry_test.go
@@ -146,6 +146,25 @@ func TestRegistrySkipsInvalidConfigMaps(t *testing.T) {
 				"remoteEntry.json": "x",
 			},
 		},
+		"duplicate route path differing only by leading slash": {
+			ObjectMeta: metav1.ObjectMeta{Name: "cm"},
+			Data: map[string]string{
+				"manifest.json": `{"name":"plugin","version":"0.1.0","entry":"index.js","federation":{"remoteEntry":"remoteEntry.json","routes":[
+					{"path":"/plugin","sidebarLabel":"Plugin","exposedModule":"./Page"},
+					{"path":"plugin","sidebarLabel":"Plugin Again","exposedModule":"./OtherPage"}
+				]}}`,
+				"index.js":         "x",
+				"remoteEntry.json": "x",
+			},
+		},
+		"federation with no routes": {
+			ObjectMeta: metav1.ObjectMeta{Name: "cm"},
+			Data: map[string]string{
+				"manifest.json":    `{"name":"plugin","version":"0.1.0","entry":"index.js","federation":{"remoteEntry":"remoteEntry.json","routes":[]}}`,
+				"index.js":         "x",
+				"remoteEntry.json": "x",
+			},
+		},
 		"federation missing remoteEntry": {
 			ObjectMeta: metav1.ObjectMeta{Name: "cm"},
 			Data: map[string]string{
@@ -156,7 +175,7 @@ func TestRegistrySkipsInvalidConfigMaps(t *testing.T) {
 		"federation remoteEntry file not present": {
 			ObjectMeta: metav1.ObjectMeta{Name: "cm"},
 			Data: map[string]string{
-				"manifest.json": `{"name":"plugin","version":"0.1.0","entry":"index.js","federation":{"remoteEntry":"remoteEntry.json"}}`,
+				"manifest.json": `{"name":"plugin","version":"0.1.0","entry":"index.js","federation":{"remoteEntry":"remoteEntry.json","routes":[{"path":"/plugin","sidebarLabel":"Plugin","exposedModule":"./Page"}]}}`,
 				"index.js":      "x",
 			},
 		},

--- a/pkg/plugins/registry_test.go
+++ b/pkg/plugins/registry_test.go
@@ -110,6 +110,29 @@ func TestRegistrySkipsInvalidConfigMaps(t *testing.T) {
 				"index.js":      "x",
 			},
 		},
+		"route missing sidebarLabel": {
+			ObjectMeta: metav1.ObjectMeta{Name: "cm"},
+			Data: map[string]string{
+				"manifest.json":    `{"name":"plugin","version":"0.1.0","entry":"index.js","route":{"path":"/plugin"},"federation":{"remoteEntry":"remoteEntry.json","exposedModule":"./Page"}}`,
+				"index.js":         "x",
+				"remoteEntry.json": "x",
+			},
+		},
+		"route without federation": {
+			ObjectMeta: metav1.ObjectMeta{Name: "cm"},
+			Data: map[string]string{
+				"manifest.json": `{"name":"plugin","version":"0.1.0","entry":"index.js","route":{"path":"/plugin","sidebarLabel":"Plugin"}}`,
+				"index.js":      "x",
+			},
+		},
+		"route path under reserved api/ prefix": {
+			ObjectMeta: metav1.ObjectMeta{Name: "cm"},
+			Data: map[string]string{
+				"manifest.json":    `{"name":"plugin","version":"0.1.0","entry":"index.js","route":{"path":"/api/v1/plugin","sidebarLabel":"Plugin"},"federation":{"remoteEntry":"remoteEntry.json","exposedModule":"./Page"}}`,
+				"index.js":         "x",
+				"remoteEntry.json": "x",
+			},
+		},
 		"federation missing remoteEntry": {
 			ObjectMeta: metav1.ObjectMeta{Name: "cm"},
 			Data: map[string]string{

--- a/pkg/plugins/registry_test.go
+++ b/pkg/plugins/registry_test.go
@@ -106,14 +106,23 @@ func TestRegistrySkipsInvalidConfigMaps(t *testing.T) {
 		"route missing path": {
 			ObjectMeta: metav1.ObjectMeta{Name: "cm"},
 			Data: map[string]string{
-				"manifest.json": `{"name":"plugin","version":"0.1.0","entry":"index.js","route":{"sidebarLabel":"Plugin"}}`,
-				"index.js":      "x",
+				"manifest.json":    `{"name":"plugin","version":"0.1.0","entry":"index.js","routes":[{"sidebarLabel":"Plugin","exposedModule":"./Page"}],"federation":{"remoteEntry":"remoteEntry.json"}}`,
+				"index.js":         "x",
+				"remoteEntry.json": "x",
 			},
 		},
 		"route missing sidebarLabel": {
 			ObjectMeta: metav1.ObjectMeta{Name: "cm"},
 			Data: map[string]string{
-				"manifest.json":    `{"name":"plugin","version":"0.1.0","entry":"index.js","route":{"path":"/plugin"},"federation":{"remoteEntry":"remoteEntry.json","exposedModule":"./Page"}}`,
+				"manifest.json":    `{"name":"plugin","version":"0.1.0","entry":"index.js","routes":[{"path":"/plugin","exposedModule":"./Page"}],"federation":{"remoteEntry":"remoteEntry.json"}}`,
+				"index.js":         "x",
+				"remoteEntry.json": "x",
+			},
+		},
+		"route missing exposedModule": {
+			ObjectMeta: metav1.ObjectMeta{Name: "cm"},
+			Data: map[string]string{
+				"manifest.json":    `{"name":"plugin","version":"0.1.0","entry":"index.js","routes":[{"path":"/plugin","sidebarLabel":"Plugin"}],"federation":{"remoteEntry":"remoteEntry.json"}}`,
 				"index.js":         "x",
 				"remoteEntry.json": "x",
 			},
@@ -121,14 +130,25 @@ func TestRegistrySkipsInvalidConfigMaps(t *testing.T) {
 		"route without federation": {
 			ObjectMeta: metav1.ObjectMeta{Name: "cm"},
 			Data: map[string]string{
-				"manifest.json": `{"name":"plugin","version":"0.1.0","entry":"index.js","route":{"path":"/plugin","sidebarLabel":"Plugin"}}`,
+				"manifest.json": `{"name":"plugin","version":"0.1.0","entry":"index.js","routes":[{"path":"/plugin","sidebarLabel":"Plugin","exposedModule":"./Page"}]}`,
 				"index.js":      "x",
 			},
 		},
 		"route path under reserved api/ prefix": {
 			ObjectMeta: metav1.ObjectMeta{Name: "cm"},
 			Data: map[string]string{
-				"manifest.json":    `{"name":"plugin","version":"0.1.0","entry":"index.js","route":{"path":"/api/v1/plugin","sidebarLabel":"Plugin"},"federation":{"remoteEntry":"remoteEntry.json","exposedModule":"./Page"}}`,
+				"manifest.json":    `{"name":"plugin","version":"0.1.0","entry":"index.js","routes":[{"path":"/api/v1/plugin","sidebarLabel":"Plugin","exposedModule":"./Page"}],"federation":{"remoteEntry":"remoteEntry.json"}}`,
+				"index.js":         "x",
+				"remoteEntry.json": "x",
+			},
+		},
+		"duplicate route path in the same manifest": {
+			ObjectMeta: metav1.ObjectMeta{Name: "cm"},
+			Data: map[string]string{
+				"manifest.json": `{"name":"plugin","version":"0.1.0","entry":"index.js","routes":[
+					{"path":"/plugin","sidebarLabel":"Plugin","exposedModule":"./Page"},
+					{"path":"/plugin","sidebarLabel":"Plugin Again","exposedModule":"./OtherPage"}
+				],"federation":{"remoteEntry":"remoteEntry.json"}}`,
 				"index.js":         "x",
 				"remoteEntry.json": "x",
 			},
@@ -136,22 +156,14 @@ func TestRegistrySkipsInvalidConfigMaps(t *testing.T) {
 		"federation missing remoteEntry": {
 			ObjectMeta: metav1.ObjectMeta{Name: "cm"},
 			Data: map[string]string{
-				"manifest.json": `{"name":"plugin","version":"0.1.0","entry":"index.js","federation":{"exposedModule":"./Page"}}`,
+				"manifest.json": `{"name":"plugin","version":"0.1.0","entry":"index.js","federation":{}}`,
 				"index.js":      "x",
-			},
-		},
-		"federation missing exposedModule": {
-			ObjectMeta: metav1.ObjectMeta{Name: "cm"},
-			Data: map[string]string{
-				"manifest.json":    `{"name":"plugin","version":"0.1.0","entry":"index.js","federation":{"remoteEntry":"remoteEntry.json"}}`,
-				"index.js":         "x",
-				"remoteEntry.json": "x",
 			},
 		},
 		"federation remoteEntry file not present": {
 			ObjectMeta: metav1.ObjectMeta{Name: "cm"},
 			Data: map[string]string{
-				"manifest.json": `{"name":"plugin","version":"0.1.0","entry":"index.js","federation":{"remoteEntry":"remoteEntry.json","exposedModule":"./Page"}}`,
+				"manifest.json": `{"name":"plugin","version":"0.1.0","entry":"index.js","federation":{"remoteEntry":"remoteEntry.json"}}`,
 				"index.js":      "x",
 			},
 		},
@@ -165,7 +177,7 @@ func TestRegistrySkipsInvalidConfigMaps(t *testing.T) {
 	}
 }
 
-func TestRegistryIndexIncludesRouteAndFederation(t *testing.T) {
+func TestRegistryIndexIncludesRoutesAndFederation(t *testing.T) {
 	r := newTestRegistry(t)
 
 	r.handleUpsert(&corev1.ConfigMap{
@@ -175,8 +187,11 @@ func TestRegistryIndexIncludesRouteAndFederation(t *testing.T) {
 				"name": "policy-management",
 				"version": "0.2.0",
 				"entry": "index.js",
-				"route": {"path": "/policies", "sidebarLabel": "Policy Management", "icon": "M0 0h16v16H0z"},
-				"federation": {"remoteEntry": "remoteEntry.json", "exposedModule": "./PolicyManagementPage"}
+				"routes": [
+					{"path": "/policies", "sidebarLabel": "Policy Management", "icon": "M0 0h16v16H0z", "exposedModule": "./PolicyManagementPage"},
+					{"path": "/policies/audit", "sidebarLabel": "Policy Audit Log", "exposedModule": "./PolicyAuditPage"}
+				],
+				"federation": {"remoteEntry": "remoteEntry.json"}
 			}`,
 			"index.js":         "x",
 			"remoteEntry.json": "{}",
@@ -187,12 +202,11 @@ func TestRegistryIndexIncludesRouteAndFederation(t *testing.T) {
 		Name:    "policy-management",
 		Version: "0.2.0",
 		Entry:   "index.js",
-		Route: &apisv1.PluginRoute{
-			Path:         "/policies",
-			SidebarLabel: "Policy Management",
-			Icon:         "M0 0h16v16H0z",
+		Routes: []apisv1.PluginRoute{
+			{Path: "/policies", SidebarLabel: "Policy Management", Icon: "M0 0h16v16H0z", ExposedModule: "./PolicyManagementPage"},
+			{Path: "/policies/audit", SidebarLabel: "Policy Audit Log", ExposedModule: "./PolicyAuditPage"},
 		},
-		Federation: &apisv1.PluginFederation{RemoteEntry: "remoteEntry.json", ExposedModule: "./PolicyManagementPage"},
+		Federation: &apisv1.PluginFederation{RemoteEntry: "remoteEntry.json"},
 	}}, r.Index())
 }
 


### PR DESCRIPTION
## Add optional `route` and `federation` fields to `PluginManifest`

### Why

Today the host has to `import()` (and fully execute) every installed plugin at
startup just to learn its route — a plugin registers by calling
`registerRoute()`/`registerSidebarEntry()` (`@antrea/ui-plugin-sdk`) as a side
effect of its code running. For a plugin loaded via module federation, that
defeats the point: federation exists to defer fetching a plugin's code (and
share large deps like Angular/Clarity) until it's actually needed.

This PR adds two optional fields to `PluginManifest` so a whole-page plugin
can declare its route as **data**, and flag that its entry file is a
federation remote. Both are additive — existing manifests and the
`registerX()` SDK contract are unaffected.

### What's new

```go
Route      *PluginRoute      `json:"route,omitempty"`      // {path, sidebarLabel, icon}
Federation *PluginFederation `json:"federation,omitempty"` // {exposedModule}
```

### Example

Take `pod-counter` (`plugins/examples/pod-counter`) — today a plain Vite
bundle with `manifest.json: {name, version, entry}`. Rebuilt as a federation
remote instead, it would ship:

```json
{
  "name": "pod-counter",
  "entry": "remoteEntry.json",
  "route": { "path": "/pod-counter", "sidebarLabel": "Pod Counter" },
  "federation": { "exposedModule": "./PodCounterPage" }
}
```

- `entry` now points at the plugin's federation manifest (`remoteEntry.json`,
  generated by its own build), not a plain JS module.
- `federation.exposedModule` names which of that remote's exposed modules to
  load — must match the key the plugin declared in its own build config
  (e.g. `exposes: { './PodCounterPage': ... }`).
- `route.path`/`sidebarLabel` are the same info `registerRoute()`/
  `registerSidebarEntry()` carry today, just readable off the manifest with
  no plugin code execution required.

A federation-aware host builds a lazy route straight from this data:

```ts
{
  path: manifest.route.path,
  loadComponent: () => loadRemoteModule({
    remoteEntry: entryUrl, exposedModule: manifest.federation.exposedModule,
  }).then(m => m.PodCounterPageComponent),
}
```

The plugin's code only loads on first navigation to that route. A host
without federation support, or a manifest omitting these fields, is
unaffected — it keeps `import()`-ing `entry` eagerly as today.

### What doesn't change

Page-extension plugins (edge details, flow table columns) keep using
`registerEdgeExtraRenderer()`/`registerFlowTableColumnsProcessor()`
unchanged — those need an actual function reference the host calls
synchronously, which a manifest field can't express. Backend file serving
also needs no changes: it already serves any file in a plugin's ConfigMap by
name, so `remoteEntry.json` and its build chunks work as-is.
