### PR TITLE
Add shared nested-nav primitive and split Flow Visibility into sub-pages

### DIFF
--- a/client/web/antrea-ui-components/src/antrea-nav.test.ts
+++ b/client/web/antrea-ui-components/src/antrea-nav.test.ts
@@ -53,8 +53,24 @@ describe('antrea-nav-group', () => {
         expect(group.expanded).toBe(true);
     });
 
-    test('clicking anywhere in the header slot (not just the toggle button) also toggles the group', async () => {
+    test('clicking the header slot expands a collapsed group', async () => {
         const group = mount();
+        const headerLink = document.createElement('a');
+        headerLink.slot = 'header';
+        headerLink.textContent = 'Flow Visibility';
+        group.append(headerLink);
+        await group.updateComplete;
+
+        headerLink.click();
+        await group.updateComplete;
+
+        expect(group.expanded).toBe(true);
+    });
+
+    test('clicking the header slot never collapses an already-expanded group', async () => {
+        // Distinct from the toggle button: the header slot also navigates (it's the group's own
+        // link), so collapsing on click would hide the page just navigated to.
+        const group = mount(true);
         const headerLink = document.createElement('a');
         headerLink.slot = 'header';
         headerLink.textContent = 'Flow Visibility';
@@ -69,6 +85,23 @@ describe('antrea-nav-group', () => {
 
     test('clicking the toggle button again collapses it back', async () => {
         const group = mount(true);
+        await group.updateComplete;
+
+        const toggle = group.shadowRoot!.querySelector('.group-toggle') as HTMLButtonElement;
+        toggle.click();
+        await group.updateComplete;
+
+        expect(group.expanded).toBe(false);
+    });
+
+    test('clicking the toggle button collapses even with a header link present (stopPropagation)', async () => {
+        // Without stopPropagation, the click would bubble from the button to the header row and
+        // re-expand it there, masking the collapse.
+        const group = mount(true);
+        const headerLink = document.createElement('a');
+        headerLink.slot = 'header';
+        headerLink.textContent = 'Flow Visibility';
+        group.append(headerLink);
         await group.updateComplete;
 
         const toggle = group.shadowRoot!.querySelector('.group-toggle') as HTMLButtonElement;

--- a/client/web/antrea-ui-components/src/antrea-nav.test.ts
+++ b/client/web/antrea-ui-components/src/antrea-nav.test.ts
@@ -111,6 +111,20 @@ describe('antrea-nav-group', () => {
         expect(group.expanded).toBe(false);
     });
 
+    test('hasActiveChild turning true after mount (not just at mount) expands the group', async () => {
+        // Covers a host whose route guard resolves after this element's first render — e.g. a
+        // redirect still in flight, or an access summary that hasn't loaded yet — so hasActiveChild
+        // starts false and only later becomes true, rather than being true from the start.
+        const group = mount(false);
+        await group.updateComplete;
+        expect(group.expanded).toBe(false);
+
+        group.hasActiveChild = true;
+        await group.updateComplete;
+
+        expect(group.expanded).toBe(true);
+    });
+
     test('hasActiveChild flipping after first render does not re-collapse or re-expand the group', async () => {
         const group = mount(true);
         await group.updateComplete;

--- a/client/web/antrea-ui-components/src/antrea-nav.test.ts
+++ b/client/web/antrea-ui-components/src/antrea-nav.test.ts
@@ -1,0 +1,94 @@
+// Copyright 2026 Antrea Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+import { afterEach, describe, expect, test } from 'vitest';
+import './antrea-nav';
+import type { AntreaNavGroup } from './antrea-nav';
+
+afterEach(() => {
+    document.body.replaceChildren();
+});
+
+function mount(hasActiveChild = false): AntreaNavGroup {
+    const group = document.createElement('antrea-nav-group') as AntreaNavGroup;
+    group.hasActiveChild = hasActiveChild;
+    document.body.append(group);
+    return group;
+}
+
+describe('antrea-nav-group', () => {
+    test('starts collapsed when it has no active child', async () => {
+        const group = mount();
+        await group.updateComplete;
+
+        expect(group.expanded).toBe(false);
+    });
+
+    test('starts expanded when the host reports an active child', async () => {
+        const group = mount(true);
+        await group.updateComplete;
+
+        expect(group.expanded).toBe(true);
+    });
+
+    test('clicking the toggle button expands a collapsed group', async () => {
+        const group = mount();
+        await group.updateComplete;
+
+        const toggle = group.shadowRoot!.querySelector('.group-toggle') as HTMLButtonElement;
+        toggle.click();
+        await group.updateComplete;
+
+        expect(group.expanded).toBe(true);
+    });
+
+    test('clicking anywhere in the header slot (not just the toggle button) also toggles the group', async () => {
+        const group = mount();
+        const headerLink = document.createElement('a');
+        headerLink.slot = 'header';
+        headerLink.textContent = 'Flow Visibility';
+        group.append(headerLink);
+        await group.updateComplete;
+
+        headerLink.click();
+        await group.updateComplete;
+
+        expect(group.expanded).toBe(true);
+    });
+
+    test('clicking the toggle button again collapses it back', async () => {
+        const group = mount(true);
+        await group.updateComplete;
+
+        const toggle = group.shadowRoot!.querySelector('.group-toggle') as HTMLButtonElement;
+        toggle.click();
+        await group.updateComplete;
+
+        expect(group.expanded).toBe(false);
+    });
+
+    test('hasActiveChild flipping after first render does not re-collapse or re-expand the group', async () => {
+        const group = mount(true);
+        await group.updateComplete;
+        expect(group.expanded).toBe(true);
+
+        // Simulates navigating away from the active child without unmounting the group (e.g. a
+        // route change elsewhere in the sidebar) — the user's (or the initial auto-expand's)
+        // state should stick rather than fight subsequent prop changes.
+        group.hasActiveChild = false;
+        await group.updateComplete;
+
+        expect(group.expanded).toBe(true);
+    });
+});

--- a/client/web/antrea-ui-components/src/antrea-nav.ts
+++ b/client/web/antrea-ui-components/src/antrea-nav.ts
@@ -202,9 +202,9 @@ export class AntreaNavItem extends LitElement {
  * the expand/collapse chrome, so any host or plugin gets the same nested-nav rendering without
  * reimplementing it.
  *
- * Clicking anywhere in the header row toggles expand/collapse (not just the chevron) — the click
- * handler lives on the row, and the header slot's own click (e.g. its Link) still navigates as
- * normal since toggling doesn't preventDefault. Clicking again while expanded collapses it.
+ * Clicking the header slot (e.g. its Link) always expands — never collapses — since it also
+ * navigates to the group's own page, and hiding the destination just navigated to would be
+ * confusing. Only the chevron button actually toggles, including collapsing when expanded.
  *
  * @slot header - The group's own antrea-nav-item (its link, icon, active state)
  * @slot - Nested antrea-nav-item elements, shown when expanded
@@ -279,17 +279,25 @@ export class AntreaNavGroup extends LitElement {
         if (this.hasActiveChild) this.expanded = true;
     }
 
-    private _handleToggle() {
+    private _handleToggleClick(e: Event) {
+        // Stops the click from also reaching _handleHeaderClick below — this is the one control
+        // allowed to collapse an expanded group.
+        e.stopPropagation();
         this.expanded = !this.expanded;
+    }
+
+    private _handleHeaderClick() {
+        this.expanded = true;
     }
 
     render() {
         return html`
-            <div class="group-header" @click=${this._handleToggle}>
+            <div class="group-header" @click=${this._handleHeaderClick}>
                 <slot name="header"></slot>
                 <button
                     class="group-toggle"
                     part="toggle"
+                    @click=${this._handleToggleClick}
                     aria-label=${this.expanded ? 'Collapse group' : 'Expand group'}
                     aria-expanded=${this.expanded}
                 >

--- a/client/web/antrea-ui-components/src/antrea-nav.ts
+++ b/client/web/antrea-ui-components/src/antrea-nav.ts
@@ -193,12 +193,124 @@ export class AntreaNavItem extends LitElement {
     }
 }
 
+/**
+ * Collapsible wrapper for a nested group of antrea-nav-item elements — e.g. Flow Visibility's
+ * Flow List / Service Map sub-pages, or a plugin's own nested entries (see
+ * `@antrea/ui-plugin-sdk`'s `PluginSidebarEntry.parentPath`). Active-item highlighting is not
+ * this component's job: put an `active` antrea-nav-item in the "header" slot for the group's own
+ * page, and give nested antrea-nav-items their own `active` as usual — this component only owns
+ * the expand/collapse chrome, so any host or plugin gets the same nested-nav rendering without
+ * reimplementing it.
+ *
+ * Clicking anywhere in the header row toggles expand/collapse (not just the chevron) — the click
+ * handler lives on the row, and the header slot's own click (e.g. its Link) still navigates as
+ * normal since toggling doesn't preventDefault. Clicking again while expanded collapses it.
+ *
+ * @slot header - The group's own antrea-nav-item (its link, icon, active state)
+ * @slot - Nested antrea-nav-item elements, shown when expanded
+ * @attr expanded - Reflects whether the group is currently expanded
+ * @prop hasActiveChild - Set by the host when one of the nested items is the current page, so the
+ *   group starts expanded instead of hiding the active page behind a collapsed toggle. Only
+ *   consulted on first render — afterwards, the user's own toggle sticks.
+ *
+ * CSS tokens consumed:
+ *   --antrea-nav-item-text, --antrea-nav-item-text-active, --antrea-space-md
+ */
+export class AntreaNavGroup extends LitElement {
+    static styles = css`
+        :host {
+            display: block;
+        }
+
+        .group-header {
+            display: flex;
+            align-items: stretch;
+            cursor: pointer;
+        }
+
+        .group-header ::slotted(*) {
+            flex: 1;
+            min-width: 0;
+        }
+
+        .group-toggle {
+            display: flex;
+            align-items: center;
+            justify-content: center;
+            flex-shrink: 0;
+            width: 32px;
+            background: none;
+            border: none;
+            cursor: pointer;
+            color: var(--antrea-nav-item-text, #adbbc4);
+        }
+
+        .group-header:hover .group-toggle {
+            color: var(--antrea-nav-item-text-active, #e9ecef);
+        }
+
+        .toggle-icon {
+            display: inline-block;
+            width: 7px;
+            height: 7px;
+            border-right: 2px solid currentColor;
+            border-bottom: 2px solid currentColor;
+            transform: rotate(45deg);
+            transition: transform 0.15s;
+        }
+
+        :host([expanded]) .toggle-icon {
+            transform: rotate(225deg);
+        }
+
+        .group-children {
+            padding-left: var(--antrea-space-md, 1rem);
+        }
+
+        .group-children.collapsed {
+            display: none;
+        }
+    `;
+
+    @property({ type: Boolean, reflect: true }) expanded = false;
+    @property({ type: Boolean }) hasActiveChild = false;
+
+    protected firstUpdated() {
+        if (this.hasActiveChild) this.expanded = true;
+    }
+
+    private _handleToggle() {
+        this.expanded = !this.expanded;
+    }
+
+    render() {
+        return html`
+            <div class="group-header" @click=${this._handleToggle}>
+                <slot name="header"></slot>
+                <button
+                    class="group-toggle"
+                    part="toggle"
+                    aria-label=${this.expanded ? 'Collapse group' : 'Expand group'}
+                    aria-expanded=${this.expanded}
+                >
+                    <span class="toggle-icon"></span>
+                </button>
+            </div>
+            <div class="group-children ${this.expanded ? '' : 'collapsed'}">
+                <slot></slot>
+            </div>
+        `;
+    }
+}
+
 customElements.define('antrea-nav', AntreaNav);
 customElements.define('antrea-nav-item', AntreaNavItem);
+customElements.define('antrea-nav-group', AntreaNavGroup);
 
 declare global {
     interface HTMLElementTagNameMap {
         'antrea-nav': AntreaNav;
         'antrea-nav-item': AntreaNavItem;
+        'antrea-nav-group': AntreaNavGroup;
     }
 }

--- a/client/web/antrea-ui-components/src/antrea-nav.ts
+++ b/client/web/antrea-ui-components/src/antrea-nav.ts
@@ -13,6 +13,7 @@
 // limitations under the License.
 
 import { LitElement, html, css } from 'lit';
+import type { PropertyValues } from 'lit';
 import { property } from 'lit/decorators.js';
 
 /**
@@ -210,8 +211,16 @@ export class AntreaNavItem extends LitElement {
  * @slot - Nested antrea-nav-item elements, shown when expanded
  * @attr expanded - Reflects whether the group is currently expanded
  * @prop hasActiveChild - Set by the host when one of the nested items is the current page, so the
- *   group starts expanded instead of hiding the active page behind a collapsed toggle. Only
- *   consulted on first render — afterwards, the user's own toggle sticks.
+ *   group expands instead of hiding the active page behind a collapsed toggle. Consulted on
+ *   every false-to-true transition, not just the first — a host route guard (e.g. a redirect
+ *   still in flight, or the access summary not having loaded yet, see nav.tsx) can render this
+ *   group before it knows the current page belongs inside it — but a true-to-false transition
+ *   never auto-collapses, so the user's own toggle still sticks.
+ *
+ * @csspart toggle - The expand/collapse chevron button. Exposed so a host can hide it in contexts
+ *   where there's no room for a group's nested items regardless of expand state (see App.css's
+ *   icon-only-sidebar rule, which hides both) — treat this as a stable, external contract, not an
+ *   implementation detail.
  *
  * CSS tokens consumed:
  *   --antrea-nav-item-text, --antrea-nav-item-text-active, --antrea-space-md
@@ -275,8 +284,13 @@ export class AntreaNavGroup extends LitElement {
     @property({ type: Boolean, reflect: true }) expanded = false;
     @property({ type: Boolean }) hasActiveChild = false;
 
-    protected firstUpdated() {
-        if (this.hasActiveChild) this.expanded = true;
+    protected updated(changed: PropertyValues) {
+        // Fires on the initial render too (Lit's first `changed` includes every reactive
+        // property), so this also covers the plain mount-with-an-active-child case `firstUpdated`
+        // used to handle — plus any later false-to-true transition. Only ever expands: reading
+        // `this.hasActiveChild` (not the old value) rather than diffing means a true-to-false
+        // transition is silently ignored, so the user's own toggle is never overridden.
+        if (changed.has('hasActiveChild') && this.hasActiveChild) this.expanded = true;
     }
 
     private _handleToggleClick(e: Event) {

--- a/client/web/antrea-ui-components/src/index.ts
+++ b/client/web/antrea-ui-components/src/index.ts
@@ -15,7 +15,7 @@
 export { AntreaButton } from './antrea-button.js';
 export { AntreaAlert } from './antrea-alert.js';
 export { AntreaCard } from './antrea-card.js';
-export { AntreaNav, AntreaNavItem } from './antrea-nav.js';
+export { AntreaNav, AntreaNavItem, AntreaNavGroup } from './antrea-nav.js';
 export { AntreaInput } from './antrea-input.js';
 export { AntreaSummaryPage } from './pages/antrea-summary-page.js';
 export { AntreaSettingsPage } from './pages/antrea-settings-page.js';

--- a/client/web/antrea-ui-components/src/pages/antrea-flow-visibility-page.test.ts
+++ b/client/web/antrea-ui-components/src/pages/antrea-flow-visibility-page.test.ts
@@ -160,6 +160,23 @@ describe('AntreaFlowVisibilityPage — smoke and stream lifecycle', () => {
     });
 });
 
+describe('AntreaFlowVisibilityPage — viewMode', () => {
+    // There is no in-page control for this any more (see nav.tsx's antrea-nav-group): the host
+    // drives it entirely from the URL, one-way.
+    test('defaults to list view, renders the map and updates the page title when viewMode is set to "map"', async () => {
+        const page = await mount(async () => sseResponse([]));
+        await vi.advanceTimersByTimeAsync(0);
+        expect(page.shadowRoot!.querySelector('#graph-svg')).toBeNull();
+        expect(page.shadowRoot!.querySelector('.page-title')!.textContent).toBe('Flow List');
+
+        page.viewMode = 'map';
+        await page.updateComplete;
+
+        expect(page.shadowRoot!.querySelector('#graph-svg')).not.toBeNull();
+        expect(page.shadowRoot!.querySelector('.page-title')!.textContent).toBe('Service Map');
+    });
+});
+
 describe('AntreaFlowVisibilityPage — antrea-edge-selected extension point', () => {
     async function mountWithOneEdge(): Promise<AntreaFlowVisibilityPage> {
         const page = await mount(async () => sseResponse([flowEventChunk([makeFlow({ ingressPolicy: 'allow-client' })])]));
@@ -169,7 +186,7 @@ describe('AntreaFlowVisibilityPage — antrea-edge-selected extension point', ()
         // Switch to map view — this is what triggers _buildServiceMap(), synchronously
         // populating _graphRef.edgeMap and wiring up click handlers on the rendered paths
         // (independent of the D3 force simulation, which only animates positions afterward).
-        (page as unknown as { _viewMode: string })._viewMode = 'map';
+        page.viewMode = 'map';
         await page.updateComplete;
         return page;
     }

--- a/client/web/antrea-ui-components/src/pages/antrea-flow-visibility-page.ts
+++ b/client/web/antrea-ui-components/src/pages/antrea-flow-visibility-page.ts
@@ -430,8 +430,10 @@ export class AntreaFlowVisibilityPage extends SessionAwarePage {
         .warn { color: var(--antrea-color-warning, #f5a623); }
     `];
 
-    // View
-    @state() private _viewMode: 'list' | 'map' = 'list';
+    // View. A property, not @state: Flow List and Service Map are second-level pages under Flow
+    // Visibility in the sidebar (see antrea-nav-group in @antrea/ui-components and nav.tsx), so
+    // the host drives this from the URL — there is no in-page control for it any more.
+    @property() viewMode: 'list' | 'map' = 'list';
     @state() private _paused = false;
 
     // Namespace filter menu is intersected with this once loaded, so users only see namespaces
@@ -530,7 +532,7 @@ export class AntreaFlowVisibilityPage extends SessionAwarePage {
     override updated(changed: Map<string, unknown>) {
         super.updated(changed);
         // Setup ResizeObserver once the DOM is ready
-        if (changed.has('_viewMode') && this._viewMode === 'map') {
+        if (changed.has('viewMode') && this.viewMode === 'map') {
             // The <svg> is always freshly created when switching into map view (render()
             // ternaries between list/map templates, so Lit tears down and recreates the whole
             // subtree). Reset the memoized topology key so _buildServiceMap() does a full
@@ -543,13 +545,13 @@ export class AntreaFlowVisibilityPage extends SessionAwarePage {
         // The <svg>/simulation only exist while in map view — leaving it tears down the DOM
         // Lit-side, but the simulation would otherwise keep ticking against detached nodes and
         // the ResizeObserver would keep observing until disconnectedCallback.
-        if (changed.has('_viewMode') && this._viewMode !== 'map') {
+        if (changed.has('viewMode') && this.viewMode !== 'map') {
             this._simulation?.stop();
             this._ro?.disconnect();
             this._ro = null;
         }
         // Rebuild map when entries or SVG width change
-        if ((changed.has('_entries') || changed.has('_svgWidth')) && this._viewMode === 'map') {
+        if ((changed.has('_entries') || changed.has('_svgWidth')) && this.viewMode === 'map') {
             this._buildServiceMap();
         }
         if (changed.has('_selectedEdgeKey')) {
@@ -1201,18 +1203,14 @@ export class AntreaFlowVisibilityPage extends SessionAwarePage {
             <main>
                 <div class="page-layout" style="max-width:100%">
                     <div class="row">
-                        <p class="page-title">Flow Visibility</p>
-                        <div class="btn-group">
-                            <antrea-button type="button" action=${this._viewMode === 'list' ? 'solid' : 'outline'} @click=${() => { this._viewMode = 'list'; }}>Flow List</antrea-button>
-                            <antrea-button type="button" action=${this._viewMode === 'map' ? 'solid' : 'outline'} @click=${() => { this._viewMode = 'map'; }}>Service Map</antrea-button>
-                        </div>
+                        <p class="page-title">${this.viewMode === 'list' ? 'Flow List' : 'Service Map'}</p>
                     </div>
 
                     ${this._renderFilters()}
 
                     ${this._error ? html`<antrea-alert status="danger">${this._error}</antrea-alert>` : nothing}
 
-                    ${this._viewMode === 'list' ? this._renderFlowList() : this._renderServiceMap()}
+                    ${this.viewMode === 'list' ? this._renderFlowList() : this._renderServiceMap()}
                 </div>
             </main>
         `;

--- a/client/web/antrea-ui-plugin-sdk/src/index.ts
+++ b/client/web/antrea-ui-plugin-sdk/src/index.ts
@@ -64,6 +64,10 @@ export interface PluginSidebarEntry {
     // top-level entry path (with or without a leading slash — both are accepted). Nesting is one
     // level deep: pointing this at an entry that itself has a parentPath is invalid and the host
     // drops (and logs) the nesting, falling back to a top-level entry.
+    //
+    // "summary" and "traceflow" are also gated by per-user RBAC and don't render at all for a
+    // user who fails that gate — nesting under either falls back to top-level the same way for
+    // such a user, but silently and per-user, since the parentPath itself is always valid.
     parentPath?: string;
 }
 

--- a/client/web/antrea-ui-plugin-sdk/src/index.ts
+++ b/client/web/antrea-ui-plugin-sdk/src/index.ts
@@ -58,6 +58,13 @@ export interface PluginSidebarEntry {
     // SVG path "d" data for a 16x16 (viewBox "0 0 16 16") icon, matching the style of the
     // built-in nav icons. Optional — entries without one just show a label.
     icon?: string;
+    // Nests this entry under another top-level sidebar entry, rendered as a collapsible group
+    // (see @antrea/ui-components' antrea-nav-group) instead of a flat item. Either a built-in
+    // page's path ("flows", "summary", "traceflow", "settings") or another plugin's own
+    // top-level entry path (with or without a leading slash — both are accepted). Nesting is one
+    // level deep: pointing this at an entry that itself has a parentPath is invalid and the host
+    // drops (and logs) the nesting, falling back to a top-level entry.
+    parentPath?: string;
 }
 
 // Kept in sync by hand with the identically-named interface in antrea-ui/src/plugins.ts, which

--- a/client/web/antrea-ui/src/App.css
+++ b/client/web/antrea-ui/src/App.css
@@ -107,6 +107,15 @@ antrea-nav:not([expanded]) .nav-label {
     display: none;
 }
 
+/*
+ * Same reasoning as .nav-label above, but for antrea-nav-group's own expand/collapse toggle: an
+ * icon-only sidebar has no room for a group's nested items anyway (their labels are already
+ * hidden by the rule above), so the toggle has nothing left to expand/collapse.
+ */
+antrea-nav:not([expanded]) antrea-nav-group::part(toggle) {
+    display: none;
+}
+
 .app-body {
     display: flex;
     flex: 1;

--- a/client/web/antrea-ui/src/App.css
+++ b/client/web/antrea-ui/src/App.css
@@ -108,10 +108,15 @@ antrea-nav:not([expanded]) .nav-label {
 }
 
 /*
- * Same reasoning as .nav-label above, but for antrea-nav-group's own expand/collapse toggle: an
- * icon-only sidebar has no room for a group's nested items anyway (their labels are already
- * hidden by the rule above), so the toggle has nothing left to expand/collapse.
+ * An icon-only sidebar has no room for a group's nested items: their labels are already hidden by
+ * the rule above, but the nested antrea-nav-item rows themselves aren't — they'd render as blank,
+ * full-width clickable rows under the group's icon. Hide the nested items outright (matched by
+ * the absence of slot="header", which only the group's own item carries) rather than just their
+ * labels, and hide the now-pointless toggle button along with them.
  */
+antrea-nav:not([expanded]) antrea-nav-group > antrea-nav-item:not([slot]) {
+    display: none;
+}
 antrea-nav:not([expanded]) antrea-nav-group::part(toggle) {
     display: none;
 }

--- a/client/web/antrea-ui/src/access.test.tsx
+++ b/client/web/antrea-ui/src/access.test.tsx
@@ -152,7 +152,7 @@ describe('HomeRedirect', () => {
                             <Route path="/" element={<HomeRedirect />} />
                             <Route path="/summary" element={<div data-testid="landed">summary</div>} />
                             <Route path="/traceflow" element={<div data-testid="landed">traceflow</div>} />
-                            <Route path="/flows" element={<div data-testid="landed">flows</div>} />
+                            <Route path="/flows/list" element={<div data-testid="landed">flows</div>} />
                         </Routes>
                     </MemoryRouter>
                 </AccessProvider>
@@ -174,7 +174,7 @@ describe('HomeRedirect', () => {
         await waitFor(() => expect(document.querySelector('[data-testid="landed"]')?.textContent).toBe('traceflow'));
     });
 
-    test('falls back to /flows when neither is granted', async () => {
+    test('falls back to /flows/list when neither is granted', async () => {
         renderAt(summaryWith());
         await waitFor(() => expect(document.querySelector('[data-testid="landed"]')?.textContent).toBe('flows'));
     });

--- a/client/web/antrea-ui/src/antrea-components.d.ts
+++ b/client/web/antrea-ui/src/antrea-components.d.ts
@@ -16,7 +16,7 @@
 // Allows using <antrea-button>, <antrea-input>, etc. in TSX files without
 // TypeScript errors, and provides prop type checking.
 
-import type { AntreaButton, AntreaAlert, AntreaCard, AntreaNav, AntreaNavItem, AntreaInput, EdgeExtraRenderer, FlowTableColumnsProcessor } from '@antrea/ui-components';
+import type { AntreaButton, AntreaAlert, AntreaCard, AntreaNav, AntreaNavItem, AntreaNavGroup, AntreaInput, EdgeExtraRenderer, FlowTableColumnsProcessor } from '@antrea/ui-components';
 import React from 'react';
 
 type ButtonAction = 'solid' | 'outline' | 'flat';
@@ -41,8 +41,15 @@ declare global {
             'antrea-nav': React.HTMLAttributes<AntreaNav> & {
                 expanded?: boolean | string;
             };
-            'antrea-nav-item': React.HTMLAttributes<AntreaNavItem> & {
+            // & React.Attributes (rather than plain React.HTMLAttributes, as most entries above
+            // use) so `key` type-checks when these are rendered from an array — antrea-nav-item
+            // and antrea-nav-group are the only elements here ever rendered from a
+            // pluginSidebarEntries.map() (see nav.tsx).
+            'antrea-nav-item': React.HTMLAttributes<AntreaNavItem> & React.Attributes & {
                 active?: boolean;
+            };
+            'antrea-nav-group': React.HTMLAttributes<AntreaNavGroup> & React.Attributes & {
+                hasActiveChild?: boolean;
             };
             'antrea-input': React.HTMLAttributes<AntreaInput> & {
                 ref?: React.Ref<HTMLElement & { value: string }>;
@@ -63,6 +70,7 @@ declare global {
             'antrea-flow-visibility-page': React.HTMLAttributes<HTMLElement> & React.ClassAttributes<HTMLElement> & {
                 edgeExtraRenderers?: EdgeExtraRenderer[];
                 flowTableColumnsProcessors?: FlowTableColumnsProcessor[];
+                viewMode?: 'list' | 'map';
             };
             'antrea-login-page': React.HTMLAttributes<HTMLElement> & React.ClassAttributes<HTMLElement>;
         }

--- a/client/web/antrea-ui/src/index.tsx
+++ b/client/web/antrea-ui/src/index.tsx
@@ -16,7 +16,7 @@
 
 import React from 'react';
 import ReactDOM from 'react-dom/client';
-import { createBrowserRouter } from 'react-router';
+import { createBrowserRouter, Navigate } from 'react-router';
 import { RouterProvider } from 'react-router/dom';
 import { setApiBase } from '@antrea/ui-components';
 import './index.css';
@@ -57,8 +57,19 @@ async function main() {
                     element: <TraceflowPage />,
                 },
                 {
+                    // No page of its own: Flow List and Service Map (below) are Flow
+                    // Visibility's actual second-level pages (see nav.tsx's antrea-nav-group), so
+                    // "/flows" itself just lands on the default one.
                     path: "flows",
-                    element: <FlowVisibilityPage />,
+                    element: <Navigate to="/flows/list" replace />,
+                },
+                {
+                    path: "flows/list",
+                    element: <FlowVisibilityPage view="list" />,
+                },
+                {
+                    path: "flows/map",
+                    element: <FlowVisibilityPage view="map" />,
                 },
                 {
                     path: "settings",

--- a/client/web/antrea-ui/src/nav.test.tsx
+++ b/client/web/antrea-ui/src/nav.test.tsx
@@ -83,6 +83,96 @@ describe('NavTab', () => {
     });
 });
 
+describe('NavTab — Flow Visibility built-in nesting', () => {
+    beforeEach(() => {
+        mockUseAccess.mockReturnValue({ summary: null, loaded: true });
+    });
+
+    test('Flow List and Service Map render nested under Flow Visibility, unconditionally', () => {
+        render(<NavTab pluginSidebarEntries={[]} />, { wrapper: MemoryRouter });
+
+        // Both the Flow Visibility header itself and the nested Flow List item link to
+        // /flows/list — the header IS the default sub-page's link, not a separate destination.
+        const listLinks = document.querySelectorAll('a[href="/flows/list"]');
+        const mapLink = document.querySelector('a[href="/flows/map"]');
+        expect(listLinks).toHaveLength(2);
+        expect(mapLink).not.toBeNull();
+
+        const group = mapLink!.closest('antrea-nav-group');
+        expect(group).not.toBeNull();
+        expect(listLinks[0].closest('antrea-nav-group')).toBe(group);
+        expect(listLinks[1].closest('antrea-nav-group')).toBe(group);
+    });
+
+    test('Flow Visibility group auto-expands when on the Service Map sub-page', () => {
+        render(
+            <MemoryRouter initialEntries={['/flows/map']}>
+                <NavTab pluginSidebarEntries={[]} />
+            </MemoryRouter>
+        );
+
+        const mapLink = document.querySelector('a[href="/flows/map"]');
+        const group = mapLink!.closest('antrea-nav-group') as unknown as { hasActiveChild?: boolean };
+        expect(group.hasActiveChild).toBe(true);
+
+        const mapNavItem = mapLink!.closest('antrea-nav-item') as unknown as { active?: boolean };
+        expect(mapNavItem.active).toBe(true);
+    });
+});
+
+describe('NavTab — nested plugin entries', () => {
+    beforeEach(() => {
+        mockUseAccess.mockReturnValue({ summary: null, loaded: true });
+    });
+
+    test('a plugin entry nested under another plugin entry renders inside an antrea-nav-group', () => {
+        const parentEntry: PluginSidebarEntry = { label: 'Parent', path: '/plugin/parent' };
+        const childEntry: PluginSidebarEntry = { label: 'Child', path: '/plugin/child', parentPath: 'plugin/parent' };
+        render(<NavTab pluginSidebarEntries={[parentEntry, childEntry]} />, { wrapper: MemoryRouter });
+
+        const parentLink = document.querySelector('a[href="/plugin/parent"]');
+        const childLink = document.querySelector('a[href="/plugin/child"]');
+        expect(parentLink).not.toBeNull();
+        expect(childLink).not.toBeNull();
+
+        const group = childLink!.closest('antrea-nav-group');
+        expect(group).not.toBeNull();
+        expect(parentLink!.closest('antrea-nav-group')).toBe(group);
+    });
+
+    test('a plugin entry nested under a built-in page renders inside an antrea-nav-group', () => {
+        const childEntry: PluginSidebarEntry = { label: 'Extra Flows Page', path: '/plugin/extra-flows', parentPath: 'flows' };
+        render(<NavTab pluginSidebarEntries={[childEntry]} />, { wrapper: MemoryRouter });
+
+        const flowsLink = document.querySelector('a[href="/flows/list"]');
+        const childLink = document.querySelector('a[href="/plugin/extra-flows"]');
+        expect(childLink!.closest('antrea-nav-group')).toBe(flowsLink!.closest('antrea-nav-group'));
+    });
+
+    test('the group auto-expands (hasActiveChild) when the current path matches a nested entry', () => {
+        const childEntry: PluginSidebarEntry = { label: 'Extra Flows Page', path: '/plugin/extra-flows', parentPath: 'flows' };
+        render(
+            <MemoryRouter initialEntries={['/plugin/extra-flows']}>
+                <NavTab pluginSidebarEntries={[childEntry]} />
+            </MemoryRouter>
+        );
+
+        const childLink = document.querySelector('a[href="/plugin/extra-flows"]');
+        const group = childLink!.closest('antrea-nav-group') as unknown as { hasActiveChild?: boolean };
+        expect(group.hasActiveChild).toBe(true);
+    });
+
+    test('an entry with an unresolvable parentPath is dropped from the sidebar entirely, matching getPluginSidebarEntries', () => {
+        // NavTab trusts its pluginSidebarEntries prop as already resolved (see plugins.ts's
+        // resolveParentPaths) — an entry a caller hands it directly with a dangling parentPath
+        // has no group to nest under, so it renders nothing rather than falling back to top-level.
+        const orphanEntry: PluginSidebarEntry = { label: 'Orphan', path: '/plugin/orphan', parentPath: 'no-such-parent' };
+        render(<NavTab pluginSidebarEntries={[orphanEntry]} />, { wrapper: MemoryRouter });
+
+        expect(document.querySelector('a[href="/plugin/orphan"]')).toBeNull();
+    });
+});
+
 describe('NavTab — permission gating', () => {
     test('while unloaded, renders no core items', () => {
         mockUseAccess.mockReturnValue({ summary: null, loaded: false });
@@ -91,7 +181,7 @@ describe('NavTab — permission gating', () => {
         expect(document.querySelector('a[href="/summary"]')).toBeNull();
         expect(document.querySelector('a[href="/traceflow"]')).toBeNull();
         // Flow Visibility and Settings have no per-user RBAC, so they are not gated on load.
-        expect(document.querySelector('a[href="/flows"]')).not.toBeNull();
+        expect(document.querySelector('a[href="/flows/list"]')).not.toBeNull();
         expect(document.querySelector('a[href="/settings"]')).not.toBeNull();
     });
 

--- a/client/web/antrea-ui/src/nav.test.tsx
+++ b/client/web/antrea-ui/src/nav.test.tsx
@@ -172,12 +172,25 @@ describe('NavTab — nested plugin entries', () => {
         expect(document.querySelector('a[href="/plugin/orphan"]')).toBeNull();
     });
 
-    // Unlike the dangling-parentPath case above, "traceflow" IS a real, valid parent — resolved-
-    // ParentPaths (plugins.ts) accepts it unconditionally, since it has no way to know the current
-    // user lacks the RBAC gate for it. Rendered here, not dropped: NavTab promotes it to top
-    // level instead of nesting it under a Traceflow item that itself isn't showing.
+    // Unlike the dangling-parentPath case above, "traceflow" IS a real, valid parent:
+    // resolveParentPaths (plugins.ts) accepts it unconditionally, since it has no way to know
+    // the current user lacks the RBAC gate for it. Rendered here, not dropped: NavTab promotes
+    // it to top level instead of nesting it under a Traceflow item that itself isn't showing.
     test('an entry nested under a built-in page gated off for this user renders at top level, not dropped', () => {
         mockUseAccess.mockReturnValue({ summary: summaryAllowing(), loaded: true }); // no gates granted
+        const childEntry: PluginSidebarEntry = { label: 'Extra Traceflow Page', path: '/plugin/extra-traceflow', parentPath: 'traceflow' };
+        render(<NavTab pluginSidebarEntries={[childEntry]} />, { wrapper: MemoryRouter });
+
+        expect(document.querySelector('a[href="/traceflow"]')).toBeNull();
+        const childLink = document.querySelector('a[href="/plugin/extra-traceflow"]');
+        expect(childLink).not.toBeNull();
+        expect(childLink!.closest('antrea-nav-group')).toBeNull();
+    });
+
+    // The same !show branch, reached the other way: until the access summary resolves, Traceflow
+    // doesn't render, so a child nested under it has no group to land in.
+    test('an entry nested under a built-in page renders at top level while access is still loading', () => {
+        mockUseAccess.mockReturnValue({ summary: null, loaded: false });
         const childEntry: PluginSidebarEntry = { label: 'Extra Traceflow Page', path: '/plugin/extra-traceflow', parentPath: 'traceflow' };
         render(<NavTab pluginSidebarEntries={[childEntry]} />, { wrapper: MemoryRouter });
 

--- a/client/web/antrea-ui/src/nav.test.tsx
+++ b/client/web/antrea-ui/src/nav.test.tsx
@@ -171,6 +171,40 @@ describe('NavTab — nested plugin entries', () => {
 
         expect(document.querySelector('a[href="/plugin/orphan"]')).toBeNull();
     });
+
+    // Unlike the dangling-parentPath case above, "traceflow" IS a real, valid parent — resolved-
+    // ParentPaths (plugins.ts) accepts it unconditionally, since it has no way to know the current
+    // user lacks the RBAC gate for it. Rendered here, not dropped: NavTab promotes it to top
+    // level instead of nesting it under a Traceflow item that itself isn't showing.
+    test('an entry nested under a built-in page gated off for this user renders at top level, not dropped', () => {
+        mockUseAccess.mockReturnValue({ summary: summaryAllowing(), loaded: true }); // no gates granted
+        const childEntry: PluginSidebarEntry = { label: 'Extra Traceflow Page', path: '/plugin/extra-traceflow', parentPath: 'traceflow' };
+        render(<NavTab pluginSidebarEntries={[childEntry]} />, { wrapper: MemoryRouter });
+
+        expect(document.querySelector('a[href="/traceflow"]')).toBeNull();
+        const childLink = document.querySelector('a[href="/plugin/extra-traceflow"]');
+        expect(childLink).not.toBeNull();
+        expect(childLink!.closest('antrea-nav-group')).toBeNull();
+    });
+
+    test('a parentPath and child path registered without a leading slash still highlight active and auto-expand', () => {
+        const parentEntry: PluginSidebarEntry = { label: 'Parent', path: 'plugin/parent' };
+        const childEntry: PluginSidebarEntry = { label: 'Child', path: 'plugin/child', parentPath: 'plugin/parent' };
+        render(
+            <MemoryRouter initialEntries={['/plugin/child']}>
+                <NavTab pluginSidebarEntries={[parentEntry, childEntry]} />
+            </MemoryRouter>
+        );
+
+        const childLink = document.querySelector('a[href="/plugin/child"]');
+        expect(childLink).not.toBeNull();
+        const childNavItem = childLink!.closest('antrea-nav-item') as unknown as { active?: boolean };
+        expect(childNavItem.active).toBe(true);
+
+        const group = childLink!.closest('antrea-nav-group') as unknown as { hasActiveChild?: boolean };
+        expect(group).not.toBeNull();
+        expect(group.hasActiveChild).toBe(true);
+    });
 });
 
 describe('NavTab — permission gating', () => {

--- a/client/web/antrea-ui/src/nav.test.tsx
+++ b/client/web/antrea-ui/src/nav.test.tsx
@@ -189,15 +189,18 @@ describe('NavTab — nested plugin entries', () => {
 
     // The same !show branch, reached the other way: until the access summary resolves, Traceflow
     // doesn't render, so a child nested under it has no group to land in.
-    test('an entry nested under a built-in page renders at top level while access is still loading', () => {
+    // Deliberately not promoted like the gated-off case above: promoting here would pop the entry
+    // in immediately and then jump it into the group once `loaded` resolves — a reflow the
+    // pre-existing showSummary/showTraceflow comment in NavTab argues against for the parent item
+    // itself ("entries popping in once loaded reads better than entries vanishing"). Hiding it too
+    // while unloaded keeps that reasoning consistent for its nested children.
+    test('an entry nested under a built-in page renders nothing while access is still loading', () => {
         mockUseAccess.mockReturnValue({ summary: null, loaded: false });
         const childEntry: PluginSidebarEntry = { label: 'Extra Traceflow Page', path: '/plugin/extra-traceflow', parentPath: 'traceflow' };
         render(<NavTab pluginSidebarEntries={[childEntry]} />, { wrapper: MemoryRouter });
 
         expect(document.querySelector('a[href="/traceflow"]')).toBeNull();
-        const childLink = document.querySelector('a[href="/plugin/extra-traceflow"]');
-        expect(childLink).not.toBeNull();
-        expect(childLink!.closest('antrea-nav-group')).toBeNull();
+        expect(document.querySelector('a[href="/plugin/extra-traceflow"]')).toBeNull();
     });
 
     test('a parentPath and child path registered without a leading slash still highlight active and auto-expand', () => {

--- a/client/web/antrea-ui/src/nav.tsx
+++ b/client/web/antrea-ui/src/nav.tsx
@@ -134,18 +134,31 @@ export default function NavTab({ pluginSidebarEntries }: { pluginSidebarEntries:
     // `show` is false when `path`'s own page isn't rendered at all — gated off by RBAC (Summary,
     // Traceflow), or the access summary hasn't loaded yet. plugins.ts's resolveParentPaths accepts
     // a gated built-in page as a valid parent unconditionally (it has no way to know it's gated
-    // for a given user), so a nested child would otherwise have no render site and silently
-    // disappear; promote its children to top level instead.
+    // for a given user), so a nested child would otherwise have no render site.
+    //
+    // Those two `!show` causes are deliberately not treated alike: `promoteChildrenIfHidden`
+    // (true once the access summary has loaded, for Summary/Traceflow) distinguishes "the parent
+    // is definitely gated off for this user" — promote its children to top level, so they don't
+    // silently disappear — from "we don't know yet" — hide them too, consistent with the
+    // `showSummary`/`showTraceflow` comment above ("entries popping in once loaded reads better
+    // than entries vanishing"): a promoted child would otherwise pop in immediately and then jump
+    // into the group once loaded resolves, a reflow that comment argues against for the parent
+    // item itself. `flows`/`settings`/plugin top-level entries always pass `show: true`, so their
+    // `promoteChildrenIfHidden` is never consulted.
     function withNestedChildren(
         path: string,
         show: boolean,
+        promoteChildrenIfHidden: boolean,
         item: React.ReactElement<{ slot?: string }>,
         builtinChildren: { path: string; node: React.ReactNode }[] = []
     ): React.ReactNode {
         const pluginChildren = childrenByParent.get(path) ?? [];
         const renderedPluginChildren = pluginChildren.map((child) => renderPluginNavItem(child, pathname));
 
-        if (!show) return [...builtinChildren.map((child) => child.node), ...renderedPluginChildren];
+        if (!show) {
+            if (!promoteChildrenIfHidden) return null;
+            return [...builtinChildren.map((child) => child.node), ...renderedPluginChildren];
+        }
         if (builtinChildren.length === 0 && pluginChildren.length === 0) return item;
         const hasActiveChild =
             builtinChildren.some((child) => pathStartsWith(pathname, child.path)) ||
@@ -161,7 +174,7 @@ export default function NavTab({ pluginSidebarEntries }: { pluginSidebarEntries:
 
     return (
         <antrea-nav>
-            {withNestedChildren('summary', showSummary, (
+            {withNestedChildren('summary', showSummary, loaded, (
                 <antrea-nav-item {...(pathEquals(pathname, '/summary') || pathname === '/' ? { active: true } : {})}>
                     <Link to="/summary">
                         <DashboardIcon />
@@ -169,7 +182,7 @@ export default function NavTab({ pluginSidebarEntries }: { pluginSidebarEntries:
                     </Link>
                 </antrea-nav-item>
             ))}
-            {withNestedChildren('traceflow', showTraceflow, (
+            {withNestedChildren('traceflow', showTraceflow, loaded, (
                 <antrea-nav-item {...(pathStartsWith(pathname, '/traceflow') ? { active: true } : {})}>
                     <Link to="/traceflow">
                         <TraceflowIcon />
@@ -177,7 +190,7 @@ export default function NavTab({ pluginSidebarEntries }: { pluginSidebarEntries:
                     </Link>
                 </antrea-nav-item>
             ))}
-            {withNestedChildren('flows', true, (
+            {withNestedChildren('flows', true, true, (
                 <antrea-nav-item {...(pathStartsWith(pathname, '/flows') ? { active: true } : {})}>
                     <Link to="/flows/list">
                         <EyeIcon />
@@ -206,7 +219,7 @@ export default function NavTab({ pluginSidebarEntries }: { pluginSidebarEntries:
                     ),
                 },
             ])}
-            {withNestedChildren('settings', true, (
+            {withNestedChildren('settings', true, true, (
                 <antrea-nav-item {...(pathEquals(pathname, '/settings') ? { active: true } : {})}>
                     <Link to="/settings">
                         <GearIcon />
@@ -216,6 +229,7 @@ export default function NavTab({ pluginSidebarEntries }: { pluginSidebarEntries:
             ))}
             {topLevelPluginEntries.map((entry) => withNestedChildren(
                 stripLeadingSlash(entry.path),
+                true,
                 true,
                 renderPluginNavItem(entry, pathname)
             ))}

--- a/client/web/antrea-ui/src/nav.tsx
+++ b/client/web/antrea-ui/src/nav.tsx
@@ -50,12 +50,47 @@ function isExternalUrl(path: string): boolean {
     return /^[a-z][a-z0-9+.-]*:\/\//i.test(path);
 }
 
+function stripLeadingSlash(path: string): string {
+    return path.replace(/^\//, '');
+}
+
 function GearIcon() {
     return (
         <svg width="16" height="16" viewBox="0 0 16 16" fill="currentColor" aria-hidden="true" style={{ flexShrink: 0 }}>
             <path d="M8 4.754a3.246 3.246 0 1 0 0 6.492 3.246 3.246 0 0 0 0-6.492zM5.754 8a2.246 2.246 0 1 1 4.492 0 2.246 2.246 0 0 1-4.492 0z"/>
             <path d="M9.796 1.343c-.527-1.79-3.065-1.79-3.592 0l-.094.319a.873.873 0 0 1-1.255.52l-.292-.16c-1.64-.892-3.433.902-2.54 2.541l.159.292a.873.873 0 0 1-.52 1.255l-.319.094c-1.79.527-1.79 3.065 0 3.592l.319.094a.873.873 0 0 1 .52 1.255l-.16.292c-.892 1.64.901 3.434 2.541 2.54l.292-.159a.873.873 0 0 1 1.255.52l.094.319c.527 1.79 3.065 1.79 3.592 0l.094-.319a.873.873 0 0 1 1.255-.52l.292.16c1.64.892 3.433-.902 2.54-2.541l-.159-.292a.873.873 0 0 1 .52-1.255l.319-.094c1.79-.527 1.79-3.065 0-3.592l-.319-.094a.873.873 0 0 1-.52-1.255l.16-.292c.892-1.64-.902-3.433-2.541-2.54l-.292.159a.873.873 0 0 1-1.255-.52l-.094-.319zm-2.633.283c.246-.835 1.428-.835 1.674 0l.094.319a1.873 1.873 0 0 0 2.693 1.115l.291-.16c.764-.415 1.6.42 1.184 1.185l-.159.292a1.873 1.873 0 0 0 1.116 2.692l.318.094c.835.246.835 1.428 0 1.674l-.319.094a1.873 1.873 0 0 0-1.115 2.693l.16.291c.415.764-.42 1.6-1.185 1.184l-.291-.159a1.873 1.873 0 0 0-2.693 1.116l-.094.318c-.246.835-1.428.835-1.674 0l-.094-.319a1.873 1.873 0 0 0-2.692-1.115l-.292.16c-.764.415-1.6-.42-1.184-1.185l.159-.291A1.873 1.873 0 0 0 1.945 8.93l-.319-.094c-.835-.246-.835-1.428 0-1.674l.319-.094A1.873 1.873 0 0 0 3.06 4.377l-.16-.292c-.415-.764.42-1.6 1.185-1.184l.292.159a1.873 1.873 0 0 0 2.692-1.115l.094-.319z"/>
         </svg>
+    );
+}
+
+// Renders a single plugin sidebar entry as an antrea-nav-item — used both for top-level plugin
+// entries and for entries nested under a group via parentPath (see plugins.ts's
+// resolveParentPaths).
+function renderPluginNavItem(entry: PluginSidebarEntry, pathname: string) {
+    const external = isExternalUrl(entry.path);
+    const label = (
+        <>
+            {entry.icon && (
+                <svg width="16" height="16" viewBox="0 0 16 16" fill="currentColor" aria-hidden="true" style={{ flexShrink: 0 }}>
+                    <path d={entry.icon} />
+                </svg>
+            )}
+            <span className="nav-label">{entry.label}</span>
+        </>
+    );
+    return (
+        <antrea-nav-item
+            key={entry.path}
+            {...(!external && pathname.startsWith(entry.path) ? { active: true } : {})}
+        >
+            {external ? (
+                <a href={entry.path} target="_blank" rel="noopener noreferrer">
+                    {label}
+                </a>
+            ) : (
+                <Link to={entry.path}>{label}</Link>
+            )}
+        </antrea-nav-item>
     );
 }
 
@@ -68,64 +103,101 @@ export default function NavTab({ pluginSidebarEntries }: { pluginSidebarEntries:
     const showSummary = loaded && canViewSummary(summary);
     const showTraceflow = loaded && can(summary, GATE_TRACEFLOW_CREATE);
 
+    // Plugin entries with a parentPath (already resolved/normalized by plugins.ts's
+    // resolveParentPaths — always a leading-slash-stripped path, whether that path belongs to a
+    // built-in page or another plugin's own top-level entry) are nested, not rendered inline.
+    const childrenByParent = new Map<string, PluginSidebarEntry[]>();
+    for (const entry of pluginSidebarEntries) {
+        if (!entry.parentPath) continue;
+        const siblings = childrenByParent.get(entry.parentPath) ?? [];
+        siblings.push(entry);
+        childrenByParent.set(entry.parentPath, siblings);
+    }
+    const topLevelPluginEntries = pluginSidebarEntries.filter((entry) => !entry.parentPath);
+
+    // Wraps `item` (a single antrea-nav-item, for `path`'s own page) in an antrea-nav-group
+    // covering `builtinChildren` (Flow Visibility's own Flow List / Service Map, keyed and active-
+    // checked the same way as a plugin's, so both sources share one group) plus any plugin
+    // entries registered under `path`, so both built-in pages and plugin top-level entries get
+    // the same nested-nav treatment for free. Returns `item` unchanged when nothing nests under it.
+    function withNestedChildren(
+        path: string,
+        item: React.ReactElement<{ slot?: string }>,
+        builtinChildren: { path: string; node: React.ReactNode }[] = []
+    ): React.ReactNode {
+        const pluginChildren = childrenByParent.get(path) ?? [];
+        if (builtinChildren.length === 0 && pluginChildren.length === 0) return item;
+        const hasActiveChild =
+            builtinChildren.some((child) => pathname.startsWith(child.path)) ||
+            pluginChildren.some((child) => pathname.startsWith(child.path));
+        return (
+            <antrea-nav-group key={`group-${path}`} hasActiveChild={hasActiveChild}>
+                {React.cloneElement(item, { slot: 'header' })}
+                {builtinChildren.map((child) => child.node)}
+                {pluginChildren.map((child) => renderPluginNavItem(child, pathname))}
+            </antrea-nav-group>
+        );
+    }
+
     return (
         <antrea-nav>
-            {showSummary && (
+            {showSummary && withNestedChildren('summary', (
                 <antrea-nav-item {...(pathname === '/summary' || pathname === '/' ? { active: true } : {})}>
                     <Link to="/summary">
                         <DashboardIcon />
                         <span className="nav-label">Summary</span>
                     </Link>
                 </antrea-nav-item>
-            )}
-            {showTraceflow && (
+            ))}
+            {showTraceflow && withNestedChildren('traceflow', (
                 <antrea-nav-item {...(pathname.startsWith('/traceflow') ? { active: true } : {})}>
                     <Link to="/traceflow">
                         <TraceflowIcon />
                         <span className="nav-label">Traceflow</span>
                     </Link>
                 </antrea-nav-item>
-            )}
-            <antrea-nav-item {...(pathname.startsWith('/flows') ? { active: true } : {})}>
-                <Link to="/flows">
-                    <EyeIcon />
-                    <span className="nav-label">Flow Visibility</span>
-                </Link>
-            </antrea-nav-item>
-            <antrea-nav-item {...(pathname === '/settings' ? { active: true } : {})}>
-                <Link to="/settings">
-                    <GearIcon />
-                    <span className="nav-label">Settings</span>
-                </Link>
-            </antrea-nav-item>
-            {pluginSidebarEntries.map((entry) => {
-                const external = isExternalUrl(entry.path);
-                const label = (
-                    <>
-                        {entry.icon && (
-                            <svg width="16" height="16" viewBox="0 0 16 16" fill="currentColor" aria-hidden="true" style={{ flexShrink: 0 }}>
-                                <path d={entry.icon} />
-                            </svg>
-                        )}
-                        <span className="nav-label">{entry.label}</span>
-                    </>
-                );
-                return (
-                    <React.Fragment key={entry.path}>
-                        <antrea-nav-item
-                            {...(!external && pathname.startsWith(entry.path) ? { active: true } : {})}
-                        >
-                            {external ? (
-                                <a href={entry.path} target="_blank" rel="noopener noreferrer">
-                                    {label}
-                                </a>
-                            ) : (
-                                <Link to={entry.path}>{label}</Link>
-                            )}
+            ))}
+            {withNestedChildren('flows', (
+                <antrea-nav-item {...(pathname.startsWith('/flows') ? { active: true } : {})}>
+                    <Link to="/flows/list">
+                        <EyeIcon />
+                        <span className="nav-label">Flow Visibility</span>
+                    </Link>
+                </antrea-nav-item>
+            ), [
+                {
+                    path: '/flows/list',
+                    node: (
+                        <antrea-nav-item key="/flows/list" {...(pathname === '/flows/list' ? { active: true } : {})}>
+                            <Link to="/flows/list">
+                                <span className="nav-label">Flow List</span>
+                            </Link>
                         </antrea-nav-item>
-                    </React.Fragment>
-                );
-            })}
+                    ),
+                },
+                {
+                    path: '/flows/map',
+                    node: (
+                        <antrea-nav-item key="/flows/map" {...(pathname === '/flows/map' ? { active: true } : {})}>
+                            <Link to="/flows/map">
+                                <span className="nav-label">Service Map</span>
+                            </Link>
+                        </antrea-nav-item>
+                    ),
+                },
+            ])}
+            {withNestedChildren('settings', (
+                <antrea-nav-item {...(pathname === '/settings' ? { active: true } : {})}>
+                    <Link to="/settings">
+                        <GearIcon />
+                        <span className="nav-label">Settings</span>
+                    </Link>
+                </antrea-nav-item>
+            ))}
+            {topLevelPluginEntries.map((entry) => withNestedChildren(
+                stripLeadingSlash(entry.path),
+                renderPluginNavItem(entry, pathname)
+            ))}
         </antrea-nav>
     );
 }

--- a/client/web/antrea-ui/src/nav.tsx
+++ b/client/web/antrea-ui/src/nav.tsx
@@ -54,6 +54,16 @@ function stripLeadingSlash(path: string): string {
     return path.replace(/^\//, '');
 }
 
+// Both operands are normalized before comparing: a plugin's registered path or parentPath may or
+// may not have a leading slash (dedupeByPath / plugins.ts's resolveParentPaths accept either),
+// while `pathname` from useLocation() always does.
+function pathStartsWith(pathname: string, path: string): boolean {
+    return stripLeadingSlash(pathname).startsWith(stripLeadingSlash(path));
+}
+function pathEquals(pathname: string, path: string): boolean {
+    return stripLeadingSlash(pathname) === stripLeadingSlash(path);
+}
+
 function GearIcon() {
     return (
         <svg width="16" height="16" viewBox="0 0 16 16" fill="currentColor" aria-hidden="true" style={{ flexShrink: 0 }}>
@@ -81,7 +91,7 @@ function renderPluginNavItem(entry: PluginSidebarEntry, pathname: string) {
     return (
         <antrea-nav-item
             key={entry.path}
-            {...(!external && pathname.startsWith(entry.path) ? { active: true } : {})}
+            {...(!external && pathStartsWith(pathname, entry.path) ? { active: true } : {})}
         >
             {external ? (
                 <a href={entry.path} target="_blank" rel="noopener noreferrer">
@@ -120,45 +130,55 @@ export default function NavTab({ pluginSidebarEntries }: { pluginSidebarEntries:
     // checked the same way as a plugin's, so both sources share one group) plus any plugin
     // entries registered under `path`, so both built-in pages and plugin top-level entries get
     // the same nested-nav treatment for free. Returns `item` unchanged when nothing nests under it.
+    //
+    // `show` is false when `path`'s own page isn't rendered at all — gated off by RBAC (Summary,
+    // Traceflow), or the access summary hasn't loaded yet. plugins.ts's resolveParentPaths accepts
+    // a gated built-in page as a valid parent unconditionally (it has no way to know it's gated
+    // for a given user), so a nested child would otherwise have no render site and silently
+    // disappear; promote its children to top level instead.
     function withNestedChildren(
         path: string,
+        show: boolean,
         item: React.ReactElement<{ slot?: string }>,
         builtinChildren: { path: string; node: React.ReactNode }[] = []
     ): React.ReactNode {
         const pluginChildren = childrenByParent.get(path) ?? [];
+        const renderedPluginChildren = pluginChildren.map((child) => renderPluginNavItem(child, pathname));
+
+        if (!show) return [...builtinChildren.map((child) => child.node), ...renderedPluginChildren];
         if (builtinChildren.length === 0 && pluginChildren.length === 0) return item;
         const hasActiveChild =
-            builtinChildren.some((child) => pathname.startsWith(child.path)) ||
-            pluginChildren.some((child) => pathname.startsWith(child.path));
+            builtinChildren.some((child) => pathStartsWith(pathname, child.path)) ||
+            pluginChildren.some((child) => pathStartsWith(pathname, child.path));
         return (
             <antrea-nav-group key={`group-${path}`} hasActiveChild={hasActiveChild}>
                 {React.cloneElement(item, { slot: 'header' })}
                 {builtinChildren.map((child) => child.node)}
-                {pluginChildren.map((child) => renderPluginNavItem(child, pathname))}
+                {renderedPluginChildren}
             </antrea-nav-group>
         );
     }
 
     return (
         <antrea-nav>
-            {showSummary && withNestedChildren('summary', (
-                <antrea-nav-item {...(pathname === '/summary' || pathname === '/' ? { active: true } : {})}>
+            {withNestedChildren('summary', showSummary, (
+                <antrea-nav-item {...(pathEquals(pathname, '/summary') || pathname === '/' ? { active: true } : {})}>
                     <Link to="/summary">
                         <DashboardIcon />
                         <span className="nav-label">Summary</span>
                     </Link>
                 </antrea-nav-item>
             ))}
-            {showTraceflow && withNestedChildren('traceflow', (
-                <antrea-nav-item {...(pathname.startsWith('/traceflow') ? { active: true } : {})}>
+            {withNestedChildren('traceflow', showTraceflow, (
+                <antrea-nav-item {...(pathStartsWith(pathname, '/traceflow') ? { active: true } : {})}>
                     <Link to="/traceflow">
                         <TraceflowIcon />
                         <span className="nav-label">Traceflow</span>
                     </Link>
                 </antrea-nav-item>
             ))}
-            {withNestedChildren('flows', (
-                <antrea-nav-item {...(pathname.startsWith('/flows') ? { active: true } : {})}>
+            {withNestedChildren('flows', true, (
+                <antrea-nav-item {...(pathStartsWith(pathname, '/flows') ? { active: true } : {})}>
                     <Link to="/flows/list">
                         <EyeIcon />
                         <span className="nav-label">Flow Visibility</span>
@@ -168,7 +188,7 @@ export default function NavTab({ pluginSidebarEntries }: { pluginSidebarEntries:
                 {
                     path: '/flows/list',
                     node: (
-                        <antrea-nav-item key="/flows/list" {...(pathname === '/flows/list' ? { active: true } : {})}>
+                        <antrea-nav-item key="/flows/list" {...(pathEquals(pathname, '/flows/list') ? { active: true } : {})}>
                             <Link to="/flows/list">
                                 <span className="nav-label">Flow List</span>
                             </Link>
@@ -178,7 +198,7 @@ export default function NavTab({ pluginSidebarEntries }: { pluginSidebarEntries:
                 {
                     path: '/flows/map',
                     node: (
-                        <antrea-nav-item key="/flows/map" {...(pathname === '/flows/map' ? { active: true } : {})}>
+                        <antrea-nav-item key="/flows/map" {...(pathEquals(pathname, '/flows/map') ? { active: true } : {})}>
                             <Link to="/flows/map">
                                 <span className="nav-label">Service Map</span>
                             </Link>
@@ -186,8 +206,8 @@ export default function NavTab({ pluginSidebarEntries }: { pluginSidebarEntries:
                     ),
                 },
             ])}
-            {withNestedChildren('settings', (
-                <antrea-nav-item {...(pathname === '/settings' ? { active: true } : {})}>
+            {withNestedChildren('settings', true, (
+                <antrea-nav-item {...(pathEquals(pathname, '/settings') ? { active: true } : {})}>
                     <Link to="/settings">
                         <GearIcon />
                         <span className="nav-label">Settings</span>
@@ -196,6 +216,7 @@ export default function NavTab({ pluginSidebarEntries }: { pluginSidebarEntries:
             ))}
             {topLevelPluginEntries.map((entry) => withNestedChildren(
                 stripLeadingSlash(entry.path),
+                true,
                 renderPluginNavItem(entry, pathname)
             ))}
         </antrea-nav>

--- a/client/web/antrea-ui/src/nav.tsx
+++ b/client/web/antrea-ui/src/nav.tsx
@@ -136,19 +136,18 @@ export default function NavTab({ pluginSidebarEntries }: { pluginSidebarEntries:
     // a gated built-in page as a valid parent unconditionally (it has no way to know it's gated
     // for a given user), so a nested child would otherwise have no render site.
     //
-    // Those two `!show` causes are deliberately not treated alike: `promoteChildrenIfHidden`
-    // (true once the access summary has loaded, for Summary/Traceflow) distinguishes "the parent
-    // is definitely gated off for this user" — promote its children to top level, so they don't
-    // silently disappear — from "we don't know yet" — hide them too, consistent with the
-    // `showSummary`/`showTraceflow` comment above ("entries popping in once loaded reads better
-    // than entries vanishing"): a promoted child would otherwise pop in immediately and then jump
-    // into the group once loaded resolves, a reflow that comment argues against for the parent
-    // item itself. `flows`/`settings`/plugin top-level entries always pass `show: true`, so their
-    // `promoteChildrenIfHidden` is never consulted.
+    // Those two `!show` causes are deliberately not treated alike (closing over `loaded` directly,
+    // rather than taking it as a parameter — every caller either passes `show: true`, for which it
+    // is never consulted, or is Summary/Traceflow, for which it is `loaded` itself): "the parent is
+    // definitely gated off for this user" (`loaded`) promotes its children to top level, so they
+    // don't silently disappear, while "we don't know yet" (`!loaded`) hides them too, consistent
+    // with the `showSummary`/`showTraceflow` comment above ("entries popping in once loaded reads
+    // better than entries vanishing") — a promoted child would otherwise pop in immediately and
+    // then jump into the group once loaded resolves, a reflow that comment argues against for the
+    // parent item itself.
     function withNestedChildren(
         path: string,
         show: boolean,
-        promoteChildrenIfHidden: boolean,
         item: React.ReactElement<{ slot?: string }>,
         builtinChildren: { path: string; node: React.ReactNode }[] = []
     ): React.ReactNode {
@@ -156,7 +155,7 @@ export default function NavTab({ pluginSidebarEntries }: { pluginSidebarEntries:
         const renderedPluginChildren = pluginChildren.map((child) => renderPluginNavItem(child, pathname));
 
         if (!show) {
-            if (!promoteChildrenIfHidden) return null;
+            if (!loaded) return null;
             return [...builtinChildren.map((child) => child.node), ...renderedPluginChildren];
         }
         if (builtinChildren.length === 0 && pluginChildren.length === 0) return item;
@@ -174,7 +173,7 @@ export default function NavTab({ pluginSidebarEntries }: { pluginSidebarEntries:
 
     return (
         <antrea-nav>
-            {withNestedChildren('summary', showSummary, loaded, (
+            {withNestedChildren('summary', showSummary, (
                 <antrea-nav-item {...(pathEquals(pathname, '/summary') || pathname === '/' ? { active: true } : {})}>
                     <Link to="/summary">
                         <DashboardIcon />
@@ -182,7 +181,7 @@ export default function NavTab({ pluginSidebarEntries }: { pluginSidebarEntries:
                     </Link>
                 </antrea-nav-item>
             ))}
-            {withNestedChildren('traceflow', showTraceflow, loaded, (
+            {withNestedChildren('traceflow', showTraceflow, (
                 <antrea-nav-item {...(pathStartsWith(pathname, '/traceflow') ? { active: true } : {})}>
                     <Link to="/traceflow">
                         <TraceflowIcon />
@@ -190,7 +189,7 @@ export default function NavTab({ pluginSidebarEntries }: { pluginSidebarEntries:
                     </Link>
                 </antrea-nav-item>
             ))}
-            {withNestedChildren('flows', true, true, (
+            {withNestedChildren('flows', true, (
                 <antrea-nav-item {...(pathStartsWith(pathname, '/flows') ? { active: true } : {})}>
                     <Link to="/flows/list">
                         <EyeIcon />
@@ -219,7 +218,7 @@ export default function NavTab({ pluginSidebarEntries }: { pluginSidebarEntries:
                     ),
                 },
             ])}
-            {withNestedChildren('settings', true, true, (
+            {withNestedChildren('settings', true, (
                 <antrea-nav-item {...(pathEquals(pathname, '/settings') ? { active: true } : {})}>
                     <Link to="/settings">
                         <GearIcon />
@@ -229,7 +228,6 @@ export default function NavTab({ pluginSidebarEntries }: { pluginSidebarEntries:
             ))}
             {topLevelPluginEntries.map((entry) => withNestedChildren(
                 stripLeadingSlash(entry.path),
-                true,
                 true,
                 renderPluginNavItem(entry, pathname)
             ))}

--- a/client/web/antrea-ui/src/pages.tsx
+++ b/client/web/antrea-ui/src/pages.tsx
@@ -32,8 +32,9 @@ export function HomeRedirect() {
     if (canViewSummary(summary)) return <Navigate to="/summary" replace />;
     if (can(summary, GATE_TRACEFLOW_CREATE)) return <Navigate to="/traceflow" replace />;
     // Flow Visibility has no per-user RBAC today (see docs/authentication.md), so it is always
-    // eligible and is the practical floor here.
-    return <Navigate to="/flows" replace />;
+    // eligible and is the practical floor here. Goes straight to its default sub-page (Flow
+    // List) rather than "/flows", which only exists to redirect there itself.
+    return <Navigate to="/flows/list" replace />;
 }
 
 // Wraps a page element so it only renders when predicate(summary) is true, matching the
@@ -101,11 +102,16 @@ export function TraceflowPage() {
     );
 }
 
-export function FlowVisibilityPage() {
+// view is the route's own sub-page (see index.tsx's "flows/list" / "flows/map" routes) — the sole
+// source of truth for which one is showing, flowing one-way into the Lit element's viewMode
+// property. There is no in-page control that could disagree with it: switching is entirely a
+// sidebar (nav.tsx) concern.
+export function FlowVisibilityPage({ view }: { view: 'list' | 'map' }) {
     const { ref } = useLitPage();
     return (
         <antrea-flow-visibility-page
             ref={ref}
+            viewMode={view}
             edgeExtraRenderers={getEdgeExtraRenderers()}
             flowTableColumnsProcessors={getFlowTableColumnsProcessors()}
         />

--- a/client/web/antrea-ui/src/plugins.test.ts
+++ b/client/web/antrea-ui/src/plugins.test.ts
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-import { loadPlugins, dedupeByPath, getPluginRoutes, type PluginManifest, type PluginRoute } from './plugins';
+import { loadPlugins, dedupeByPath, getPluginRoutes, resolveParentPaths, type PluginManifest, type PluginRoute, type PluginSidebarEntry } from './plugins';
 
 function jsonResponse(body: unknown, status = 200): Response {
     return new Response(JSON.stringify(body), { status });
@@ -76,6 +76,48 @@ describe('dedupeByPath', () => {
         const items = [{ path: '/plugin/pod-counter' }, { path: '/plugin/other' }];
 
         expect(dedupeByPath(items, 'route')).toEqual(items);
+    });
+});
+
+describe('resolveParentPaths', () => {
+    function entry(overrides: Partial<PluginSidebarEntry> = {}): PluginSidebarEntry {
+        return { label: 'Sub Page', path: '/plugin/sub-page', ...overrides };
+    }
+
+    test('an entry with no parentPath passes through unchanged', () => {
+        expect(resolveParentPaths([entry()])).toEqual([entry()]);
+    });
+
+    test('a parentPath matching a built-in page is kept and normalized', () => {
+        const result = resolveParentPaths([entry({ parentPath: '/flows' })]);
+        expect(result).toEqual([entry({ parentPath: 'flows' })]);
+    });
+
+    test('a parentPath matching another top-level plugin entry is kept', () => {
+        const parent = entry({ label: 'Parent', path: '/plugin/parent' });
+        const child = entry({ parentPath: 'plugin/parent' });
+
+        expect(resolveParentPaths([parent, child])).toEqual([parent, child]);
+    });
+
+    test('a parentPath with no matching top-level entry is dropped, with a logged reason', () => {
+        const errorSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
+        const child = entry({ parentPath: '/no-such-entry' });
+
+        expect(resolveParentPaths([child])).toEqual([entry()]);
+        expect(errorSpy).toHaveBeenCalledWith(expect.stringContaining('is not a top-level entry'));
+    });
+
+    test('nesting two levels deep is rejected: a parentPath pointing at an already-nested entry is dropped', () => {
+        const errorSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
+        const parent = entry({ label: 'Parent', path: '/plugin/parent' });
+        const child = entry({ label: 'Child', path: '/plugin/child', parentPath: 'plugin/parent' });
+        const grandchild = entry({ label: 'Grandchild', path: '/plugin/grandchild', parentPath: 'plugin/child' });
+
+        const result = resolveParentPaths([parent, child, grandchild]);
+
+        expect(result).toEqual([parent, child, entry({ label: 'Grandchild', path: '/plugin/grandchild' })]);
+        expect(errorSpy).toHaveBeenCalledWith(expect.stringContaining('is not a top-level entry (or is itself nested)'));
     });
 });
 

--- a/client/web/antrea-ui/src/plugins.ts
+++ b/client/web/antrea-ui/src/plugins.ts
@@ -61,10 +61,16 @@ window.__antreaPluginHost = {
     registerFlowTableColumnsProcessor: fn => flowTableColumnsProcessors.push(fn),
 };
 
-// Top-level routes owned by Antrea UI itself. A plugin's route/sidebar entry path must not
-// collide with these — react-router's behavior with two children registered under the same
-// path is undefined, and a colliding plugin could silently shadow a built-in page.
-const RESERVED_PATHS = new Set(['', 'summary', 'traceflow', 'flows', 'settings']);
+// Top-level pages owned by Antrea UI itself, and the only paths a plugin sidebar entry's
+// parentPath may nest under (see resolveParentPaths) — nesting stays one level deep, so Flow
+// Visibility's own second-level pages (flows/list, flows/map, below) are deliberately excluded
+// here even though they're also built-in.
+const BUILTIN_TOP_LEVEL_PATHS = new Set(['summary', 'traceflow', 'flows', 'settings']);
+
+// Every path owned by Antrea UI itself, top-level or not. A plugin's route/sidebar entry path
+// must not collide with any of these — react-router's behavior with two children registered
+// under the same path is undefined, and a colliding plugin could silently shadow a built-in page.
+const RESERVED_PATHS = new Set(['', ...BUILTIN_TOP_LEVEL_PATHS, 'flows/list', 'flows/map']);
 
 // A plugin's route/sidebar entry path must also not fall under this prefix: nginx proxies it
 // straight to the backend (see /api/v1/plugins/ above), so a hard refresh or direct link to
@@ -103,8 +109,37 @@ export function getPluginRoutes(): PluginRoute[] {
     return dedupeByPath(pluginRoutes, 'route');
 }
 
+// Clears parentPath on any entry whose parent doesn't resolve to a real top-level entry — a
+// built-in top-level page, or another entry that itself has no parentPath — logging why. Nesting
+// is one level deep, matching antrea-nav-group's group/item rendering, so a parentPath pointing
+// at an already-nested entry (including a built-in second-level page like flows/list) is invalid
+// rather than silently flattened into a deeper tree. Runs after dedupeByPath so parentPath is
+// resolved against the final, deduped set of paths, and normalizes a surviving parentPath to the
+// same leading-slash-stripped form as every entry's own (deduped) path, so callers building a
+// tree can compare them directly.
+export function resolveParentPaths(entries: PluginSidebarEntry[]): PluginSidebarEntry[] {
+    const topLevelPaths = new Set(BUILTIN_TOP_LEVEL_PATHS);
+    for (const entry of entries) {
+        if (!entry.parentPath) topLevelPaths.add(stripLeadingSlash(entry.path));
+    }
+    return entries.map((entry) => {
+        if (!entry.parentPath) return entry;
+        const normalizedParent = stripLeadingSlash(entry.parentPath);
+        if (!topLevelPaths.has(normalizedParent)) {
+            console.error(
+                `plugin sidebar entry for path "${entry.path}" has parentPath "${entry.parentPath}", ` +
+                'which is not a top-level entry (or is itself nested); ignoring the nesting'
+            );
+            // eslint-disable-next-line @typescript-eslint/no-unused-vars -- drop parentPath, keep the rest
+            const { parentPath: _parentPath, ...rest } = entry;
+            return rest;
+        }
+        return { ...entry, parentPath: normalizedParent };
+    });
+}
+
 export function getPluginSidebarEntries(): PluginSidebarEntry[] {
-    return dedupeByPath(pluginSidebarEntries, 'sidebar entry');
+    return resolveParentPaths(dedupeByPath(pluginSidebarEntries, 'sidebar entry'));
 }
 
 export function getEdgeExtraRenderers(): EdgeExtraRenderer[] {

--- a/docs/plugins.md
+++ b/docs/plugins.md
@@ -132,6 +132,16 @@ an external link) or vice versa; pass the same `path` to both to link them,
 as above. `registerSidebarEntry`'s optional `icon` is SVG path `d` data,
 16x16 (`viewBox="0 0 16 16"`), matching the built-in nav icons' style.
 
+An entry can also nest under another top-level entry by setting `parentPath`
+to that entry's `path` — a built-in page's (`flows`, `summary`, `traceflow`,
+`settings`) or another plugin's own top-level entry's, with or without a
+leading slash. The host renders it as a collapsible group (an
+`antrea-nav-group`, from `@antrea/ui-components` — the same primitive the
+host would use to nest, say, Flow List and Service Map under Flow Visibility)
+instead of a flat item. Nesting is one level deep: pointing `parentPath` at
+an entry that is itself nested is invalid, and the host drops the nesting
+(falling back to a top-level entry) and logs why.
+
 `@antrea/ui-plugin-sdk` is a devDependency resolved from this repo's
 workspace (`file:../../../client/web/antrea-ui-plugin-sdk` in
 `package.json`) — build it once before building any example plugin:
@@ -208,7 +218,7 @@ a plugin" above:
 | Function | Extends | Notes |
 | --- | --- | --- |
 | `registerRoute` | Router | Adds a whole new page at `route.path`, rendering `route.tag`'s custom element. |
-| `registerSidebarEntry` | Sidebar | Adds a nav entry linking to `entry.path`. |
+| `registerSidebarEntry` | Sidebar | Adds a nav entry linking to `entry.path`; nests under `entry.parentPath` if set. |
 | `registerEdgeExtraRenderer` | Service map edge details card | Called with an `EdgeSelection` on each selection change; return `null` to render nothing. |
 | `registerFlowTableColumnsProcessor` | Flow list table | Plugin-added columns aren't sortable — only built-in columns carry the sort key. |
 

--- a/docs/plugins.md
+++ b/docs/plugins.md
@@ -142,6 +142,13 @@ instead of a flat item. Nesting is one level deep: pointing `parentPath` at
 an entry that is itself nested is invalid, and the host drops the nesting
 (falling back to a top-level entry) and logs why.
 
+`summary` and `traceflow` are themselves gated by per-user RBAC (see
+[authentication.md](authentication.md)) and simply don't render for a user
+who fails that gate. Nesting under either still falls back to a top-level
+entry for such a user, same as the invalid-nesting case above — but silently,
+per user, and without dropping anything: the entry itself is always valid,
+it just isn't always nested.
+
 `@antrea/ui-plugin-sdk` is a devDependency resolved from this repo's
 workspace (`file:../../../client/web/antrea-ui-plugin-sdk` in
 `package.json`) — build it once before building any example plugin:


### PR DESCRIPTION
Introduces antrea-nav-group in antrea-ui-components for collapsible, nested sidebar entries, and extends PluginSidebarEntry with an optional parentPath so plugins can nest under a built-in page or another plugin's entry, not just the host. Flow List and Service Map become real second-level pages (/flows/list, /flows/map) under Flow Visibility using this primitive, replacing the in-page tab buttons.

Fixes #1368 

<img width="411" height="318" alt="image" src="https://github.com/user-attachments/assets/8da5309f-ee4a-45b2-8135-7ca0ead381ba" />
<img width="356" height="320" alt="image" src="https://github.com/user-attachments/assets/283dc05f-ea20-4cff-863f-86ff29a0ec00" />
<img width="399" height="330" alt="image" src="https://github.com/user-attachments/assets/22a73b28-04ab-421c-8bbb-a8af13c8e7d1" />
