### PR TITLE
Enforce the npm minimum release age when Yarn resolves versions

### DIFF
--- a/client/web/.yarnrc.yml
+++ b/client/web/.yarnrc.yml
@@ -1,1 +1,10 @@
 nodeLinker: node-modules
+
+# Refuse to resolve any npm package version published more recently than this, direct or
+# transitive. Keep in sync with the npm packageRule's minimumReleaseAge in
+# .github/renovate.json5, which covers only the versions Renovate itself proposes.
+# Applies when a version is resolved, so `yarn install --immutable` against an intact lockfile
+# is unaffected; `yarn add` and `yarn up` are subject to it. To bypass for a single command,
+# for example on a registry whose metadata carries no publish times, set
+# YARN_NPM_MINIMAL_AGE_GATE=0 in the environment.
+npmMinimalAgeGate: "10d"

--- a/client/web/antrea-ui/package.json
+++ b/client/web/antrea-ui/package.json
@@ -25,7 +25,7 @@
     "typescript": "^6.0.0",
     "vite": "^8.0.0",
     "vitest": "^4.0.5",
-    "web-vitals": "^6.0.0"
+    "web-vitals": "^6.1.1"
   },
   "scripts": {
     "start": "vite",

--- a/client/web/yarn.lock
+++ b/client/web/yarn.lock
@@ -1729,7 +1729,7 @@ __metadata:
     uuid: "npm:^14.0.0"
     vite: "npm:^8.0.0"
     vitest: "npm:^4.0.5"
-    web-vitals: "npm:^6.0.0"
+    web-vitals: "npm:^6.1.1"
   languageName: unknown
   linkType: soft
 
@@ -5697,10 +5697,10 @@ __metadata:
   languageName: node
   linkType: hard
 
-"web-vitals@npm:^6.0.0":
-  version: 6.2.0
-  resolution: "web-vitals@npm:6.2.0"
-  checksum: 10c0/b628d25494c18e4500d6ee01c9dff3dec0156f240fca2771c17789f29092fe1b5a81b2364a08f35e77532148894bc8eec53933012c747b29bdb33daa9b5d0423
+"web-vitals@npm:^6.1.1":
+  version: 6.1.1
+  resolution: "web-vitals@npm:6.1.1"
+  checksum: 10c0/46a65d39d7c73bc06f90b7a6b6ab20a72f1635294ed81a6e0d3bfa32557012005f7abf319bdd128e5bde5185b3e2c9121f7c62d51aebf97d730a56042296bace
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
minimumReleaseAge in .github/renovate.json5 constrains only the version
Renovate selects, not the version Yarn resolves into the lockfile. When
a dependency is declared with a caret range, a new release usually
satisfies it already, so the update needs no package.json edit and
degrades into a lockfile-only one, where Yarn takes whatever is newest
on the registry. #1369 is an instance: titled "Update dependency
web-vitals to v6.1.1", it merged 6.2.0, published two days earlier.
That is not only a weakened policy, since a version this fresh may not
have reached every package mirror yet and fetching it can fail with a
403, taking the frontend image build down with it.

Yarn 4.18.0, already pinned through packageManager, supports
npmMinimalAgeGate and applies it while selecting candidate versions.
Setting it to 10d in client/web/.yarnrc.yml closes the gap at its
source: Renovate runs Yarn inside the repository, so the setting
governs the resolution that produces the lockfile, transitive
dependencies included, where no age gate applied before at all. It
takes effect when a version is resolved, so `yarn install --immutable`
against an intact lockfile is unaffected.

Also move web-vitals to 6.1.1, the version #1369 meant to install,
declared as a range now that the gate makes one safe: 6.2.0 is still
two days old, so "^6.1.1" resolves to 6.1.1 until the gate is lifted.

Signed-off-by: Anlan He <anlan.he@broadcom.com>