### PR TITLE
Add an Overview landing page with cluster inventory tiles

### DIFF
--- a/build/charts/antrea-ui/templates/clusterroles.yaml
+++ b/build/charts/antrea-ui/templates/clusterroles.yaml
@@ -107,3 +107,33 @@ rules:
       - namespaces
     verbs:
       - list
+  # Overview landing page inventory tiles (client/web/antrea-ui-components/src/pages/antrea-overview-page.ts):
+  # counts of Pods/Services/Deployments/StatefulSets/DaemonSets/NetworkPolicies, read-only.
+  - apiGroups:
+      - ""
+    resources:
+      - pods
+      - services
+    verbs:
+      - list
+  - apiGroups:
+      - apps
+    resources:
+      - deployments
+      - statefulsets
+      - daemonsets
+    verbs:
+      - list
+  - apiGroups:
+      - networking.k8s.io
+    resources:
+      - networkpolicies
+    verbs:
+      - list
+  - apiGroups:
+      - crd.antrea.io
+    resources:
+      - clusternetworkpolicies
+      - networkpolicies
+    verbs:
+      - list

--- a/client/web/antrea-ui-components/src/antrea-card.ts
+++ b/client/web/antrea-ui-components/src/antrea-card.ts
@@ -38,6 +38,11 @@ export class AntreaCard extends LitElement {
             border: 1px solid var(--antrea-color-border, #314351);
             border-radius: var(--antrea-radius-md, 4px);
             overflow: hidden;
+            /* Lets a host given an explicit height (e.g. a stretched grid item) pass it through,
+               so cards laid out side by side can be made equal height. Resolves to auto — no
+               change in the usual case where the host height is content-driven. */
+            height: 100%;
+            box-sizing: border-box;
         }
 
         .card-header {

--- a/client/web/antrea-ui-components/src/index.ts
+++ b/client/web/antrea-ui-components/src/index.ts
@@ -18,10 +18,11 @@ export { AntreaCard } from './antrea-card.js';
 export { AntreaNav, AntreaNavItem } from './antrea-nav.js';
 export { AntreaInput } from './antrea-input.js';
 export { AntreaSummaryPage } from './pages/antrea-summary-page.js';
+export { AntreaOverviewPage } from './pages/antrea-overview-page.js';
 export { AntreaSettingsPage } from './pages/antrea-settings-page.js';
 export { AntreaTraceflowPage } from './pages/antrea-traceflow-page.js';
 export { AntreaFlowVisibilityPage } from './pages/antrea-flow-visibility-page.js';
-export type { EdgeSelection, EdgeExtraRenderer, FlowTableColumn, FlowTableColumnsProcessor } from './pages/antrea-flow-visibility-page.js';
+export type { EdgeSelection, EdgeExtraRenderer, FlowTableColumn, FlowTableColumnsProcessor, FlowVisibilityInitialFilter } from './pages/antrea-flow-visibility-page.js';
 export type { FlowEntry } from './lib/flow-store.js';
 export { AntreaLoginPage } from './pages/antrea-login-page.js';
 export { SessionAwarePage } from './lib/session-aware-page.js';
@@ -43,8 +44,18 @@ export {
     canNonResource,
     accessibleNamespaces,
     canViewSummary,
+    canViewOverview,
     GATE_TRACEFLOW_CREATE,
     GATE_AGENT_INFO_LIST,
     GATE_CONTROLLER_INFO_GET,
     GATE_FEATUREGATES,
+    GATE_NAMESPACES_LIST,
+    GATE_PODS_LIST,
+    GATE_SERVICES_LIST,
+    GATE_DEPLOYMENTS_LIST,
+    GATE_STATEFULSETS_LIST,
+    GATE_DAEMONSETS_LIST,
+    GATE_K8S_NETWORKPOLICIES_LIST,
+    GATE_ANTREA_CLUSTERNETWORKPOLICIES_LIST,
+    GATE_ANTREA_NETWORKPOLICIES_LIST,
 } from './lib/access-api.js';

--- a/client/web/antrea-ui-components/src/lib/access-api.ts
+++ b/client/web/antrea-ui-components/src/lib/access-api.ts
@@ -163,3 +163,22 @@ export const GATE_FEATUREGATES = { verb: 'get', url: '/featuregates' };
 export function canViewSummary(s: AccessSummary | null): boolean {
     return can(s, GATE_AGENT_INFO_LIST) || can(s, GATE_CONTROLLER_INFO_GET) || canNonResource(s, GATE_FEATUREGATES);
 }
+
+// Gates for the Overview landing page's inventory tiles — one per Kubernetes resource type it
+// reads, following the same "one predicate per page" convention as the gates above.
+export const GATE_NAMESPACES_LIST = { group: '', resource: 'namespaces', verb: 'list' };
+export const GATE_PODS_LIST = { group: '', resource: 'pods', verb: 'list' };
+export const GATE_SERVICES_LIST = { group: '', resource: 'services', verb: 'list' };
+export const GATE_DEPLOYMENTS_LIST = { group: 'apps', resource: 'deployments', verb: 'list' };
+export const GATE_STATEFULSETS_LIST = { group: 'apps', resource: 'statefulsets', verb: 'list' };
+export const GATE_DAEMONSETS_LIST = { group: 'apps', resource: 'daemonsets', verb: 'list' };
+export const GATE_K8S_NETWORKPOLICIES_LIST = { group: 'networking.k8s.io', resource: 'networkpolicies', verb: 'list' };
+export const GATE_ANTREA_CLUSTERNETWORKPOLICIES_LIST = { group: 'crd.antrea.io', resource: 'clusternetworkpolicies', verb: 'list' };
+export const GATE_ANTREA_NETWORKPOLICIES_LIST = { group: 'crd.antrea.io', resource: 'networkpolicies', verb: 'list' };
+
+export function canViewOverview(s: AccessSummary | null): boolean {
+    return can(s, GATE_NAMESPACES_LIST) || can(s, GATE_PODS_LIST) || can(s, GATE_SERVICES_LIST) ||
+        can(s, GATE_DEPLOYMENTS_LIST) || can(s, GATE_STATEFULSETS_LIST) || can(s, GATE_DAEMONSETS_LIST) ||
+        can(s, GATE_K8S_NETWORKPOLICIES_LIST) || can(s, GATE_ANTREA_CLUSTERNETWORKPOLICIES_LIST) ||
+        can(s, GATE_ANTREA_NETWORKPOLICIES_LIST);
+}

--- a/client/web/antrea-ui-components/src/pages/antrea-flow-visibility-page.test.ts
+++ b/client/web/antrea-ui-components/src/pages/antrea-flow-visibility-page.test.ts
@@ -443,6 +443,49 @@ describe('AntreaFlowVisibilityPage — namespace menu intersects accessible name
     });
 });
 
+describe('AntreaFlowVisibilityPage — initialFilter deep link', () => {
+    // Mirrors how the real host sets this: antrea-ui/src/pages.tsx assigns the property from a
+    // ref callback, which fires only after the element has already connected and run its normal
+    // onSessionReady() startup — never before append. See antrea-overview-page.ts's
+    // _navigateToServiceMap for what dispatches the navigation this property is seeded from.
+    test('seeds the pending filter and view mode once, applied after mount', async () => {
+        const fetchMock = vi.fn(async () => sseResponse([]));
+        const page = await mount(fetchMock);
+        await vi.advanceTimersByTimeAsync(0);
+        const callsBeforeFilter = streamCalls(fetchMock).length;
+
+        page.initialFilter = { namespaces: ['default'], podNames: ['web-1'], viewMode: 'map' };
+        await page.updateComplete;
+        await vi.advanceTimersByTimeAsync(0);
+
+        const calls = streamCalls(fetchMock);
+        expect(calls).toHaveLength(callsBeforeFilter + 1);
+        const url = calls[calls.length - 1][0] as string;
+        expect(url).toContain('namespaces=default');
+        expect(url).toContain('pods=web-1');
+        expect(page.shadowRoot!.querySelector('#graph-svg')).not.toBeNull();
+    });
+
+    test('a later property assignment does not re-apply the filter', async () => {
+        const fetchMock = vi.fn(async () => sseResponse([]));
+        const page = await mount(fetchMock);
+        await vi.advanceTimersByTimeAsync(0);
+
+        page.initialFilter = { namespaces: ['default'] };
+        await page.updateComplete;
+        await vi.advanceTimersByTimeAsync(0);
+        const callsAfterFirst = streamCalls(fetchMock).length;
+
+        // A React re-render could set this property again with a different value; it must be
+        // ignored, since the user may have already changed the filter manually by this point.
+        page.initialFilter = { namespaces: ['other'] };
+        await page.updateComplete;
+        await vi.advanceTimersByTimeAsync(0);
+
+        expect(streamCalls(fetchMock)).toHaveLength(callsAfterFirst);
+    });
+});
+
 describe('AntreaFlowVisibilityPage — teardown', () => {
     test('disconnectedCallback stops the stream client and removes the pointerdown listener', async () => {
         const fetchMock = vi.fn(async () => sseResponse([]));

--- a/client/web/antrea-ui-components/src/pages/antrea-flow-visibility-page.ts
+++ b/client/web/antrea-ui-components/src/pages/antrea-flow-visibility-page.ts
@@ -63,6 +63,17 @@ export interface EdgeSelection {
  * this selection. */
 export type EdgeExtraRenderer = (selection: EdgeSelection) => Node | null;
 
+/** A filter to seed this page with on mount, e.g. when arriving here from the Overview landing
+ * page's "click a Pod/Service to see its flows" links. See the `initialFilter` property below. */
+export interface FlowVisibilityInitialFilter {
+    namespaces?: string[];
+    podNames?: string[];
+    /** "namespace/name" form — run through destinationK8sServiceFilterKey by _onApplyFilters, which
+     * returns '' (dropping the entry) for a bare name. */
+    serviceNames?: string[];
+    viewMode?: 'list' | 'map';
+}
+
 /** A single column of the flow list table. */
 export interface FlowTableColumn {
     key: string;
@@ -478,6 +489,11 @@ export class AntreaFlowVisibilityPage extends SessionAwarePage {
     // `@antrea/ui-plugin-sdk`). Never set by manifest/attribute, so `attribute: false`.
     @property({ attribute: false }) edgeExtraRenderers: EdgeExtraRenderer[] = [];
     @property({ attribute: false }) flowTableColumnsProcessors: FlowTableColumnsProcessor[] = [];
+    // Lets another page (e.g. the Overview landing page) deep-link here with a filter already
+    // applied — set once by the host from a query string, so `attribute: false` like the two
+    // properties above. Applied exactly once, in updated(): see the initialFilter handling there.
+    @property({ attribute: false }) initialFilter?: FlowVisibilityInitialFilter;
+    private _initialFilterApplied = false;
 
     // Non-reactive refs
     private _store = new FlowStore();
@@ -529,6 +545,17 @@ export class AntreaFlowVisibilityPage extends SessionAwarePage {
 
     override updated(changed: Map<string, unknown>) {
         super.updated(changed);
+        // Applied at most once: the host (see antrea-ui/src/pages.tsx) sets this from the URL
+        // right after mount, and re-applying it on every subsequent property churn would stomp
+        // on filter changes the user makes afterward on this page.
+        if (changed.has('initialFilter') && this.initialFilter && !this._initialFilterApplied) {
+            this._initialFilterApplied = true;
+            this._pendingNs = this.initialFilter.namespaces ?? [];
+            this._pendingPods = this.initialFilter.podNames ?? [];
+            this._pendingServices = this.initialFilter.serviceNames ?? [];
+            if (this.initialFilter.viewMode) this._viewMode = this.initialFilter.viewMode;
+            this._onApplyFilters();
+        }
         // Setup ResizeObserver once the DOM is ready
         if (changed.has('_viewMode') && this._viewMode === 'map') {
             // The <svg> is always freshly created when switching into map view (render()

--- a/client/web/antrea-ui-components/src/pages/antrea-overview-page.test.ts
+++ b/client/web/antrea-ui-components/src/pages/antrea-overview-page.test.ts
@@ -1,0 +1,343 @@
+// Copyright 2026 Antrea Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+import { afterEach, describe, expect, test, vi } from 'vitest';
+import './antrea-overview-page';
+import type { AntreaOverviewPage } from './antrea-overview-page';
+import { resetAccessSummary } from '../lib/access-api';
+import type { AccessSummary } from '../lib/access-api';
+
+function jsonResponse(body: unknown, status = 200): Response {
+    return new Response(JSON.stringify(body), { status });
+}
+
+function item(name: string, namespace?: string) {
+    return { metadata: namespace ? { name, namespace } : { name } };
+}
+
+function list(names: string[], namespace?: string) {
+    return { items: names.map(n => item(n, namespace)) };
+}
+
+function fullAccessSummary(): AccessSummary {
+    return {
+        username: 'alice',
+        groups: [],
+        clusterAdmin: true,
+        rules: {
+            resourceRules: [{ apiGroups: ['*'], resources: ['*'], verbs: ['*'] }],
+            nonResourceRules: [{ nonResourceURLs: ['*'], verbs: ['*'] }],
+            incomplete: false,
+        },
+        namespaces: ['*'],
+    };
+}
+
+// Maps a request URL back to the RESOURCES key it corresponds to (see antrea-overview-page.ts),
+// so tests can stub responses by resource name instead of by exact k8s proxy path.
+function keyForUrl(rawUrl: string): string | null {
+    // Every list request carries a ?limit= (see withPageLimit in antrea-overview-page.ts); match
+    // on the path alone so these stay path assertions.
+    const url = rawUrl.split('?')[0];
+    if (url.endsWith('/access-summary')) return 'access-summary';
+    if (url.endsWith('/api/v1/namespaces')) return 'namespaces';
+    if (url.includes('/networking.k8s.io/v1/') && url.endsWith('/networkpolicies')) return 'k8sNetworkPolicies';
+    if (url.includes('/crd.antrea.io/v1beta1/') && url.endsWith('/clusternetworkpolicies')) return 'antreaClusterNetworkPolicies';
+    if (url.includes('/crd.antrea.io/v1beta1/') && url.endsWith('/networkpolicies')) return 'antreaNetworkPolicies';
+    if (url.endsWith('/pods')) return 'pods';
+    if (url.endsWith('/services')) return 'services';
+    if (url.endsWith('/deployments')) return 'deployments';
+    if (url.endsWith('/statefulsets')) return 'statefulsets';
+    if (url.endsWith('/daemonsets')) return 'daemonsets';
+    return null;
+}
+
+let el: AntreaOverviewPage | undefined;
+
+afterEach(() => {
+    el?.remove();
+    el = undefined;
+    vi.unstubAllGlobals();
+    resetAccessSummary();
+});
+
+/** Mounts the page against an arbitrary fetch handler, for cases mount()'s by-resource-key
+ * stubbing cannot express (per-URL status codes, namespace-scoped path assertions). */
+async function mountWith(handler: (url: string) => Promise<Response>): Promise<AntreaOverviewPage> {
+    vi.stubGlobal('fetch', vi.fn(handler));
+    el = document.createElement('antrea-overview-page') as AntreaOverviewPage;
+    document.body.appendChild(el);
+    await el.updateComplete;
+    await new Promise(r => setTimeout(r, 0));
+    await new Promise(r => setTimeout(r, 0));
+    await el.updateComplete;
+    return el;
+}
+
+async function mount(
+    overrides: Partial<Record<string, unknown>> = {},
+    summary: AccessSummary | null = fullAccessSummary(),
+): Promise<AntreaOverviewPage> {
+    return mountWith(async (url: string) => {
+        const key = keyForUrl(url);
+        if (key === 'access-summary') {
+            return summary === null ? new Response('', { status: 500 }) : jsonResponse(summary);
+        }
+        if (key && key in overrides) return jsonResponse(overrides[key]);
+        if (key) return jsonResponse({ items: [] });
+        throw new Error(`unexpected fetch to ${url}`);
+    });
+}
+
+function tileValue(page: AntreaOverviewPage, heading: string): string | null {
+    const value = page.shadowRoot!.querySelector(`antrea-card[heading="${heading}"] .stat-value`);
+    return value ? (value.textContent ?? '').trim() : null;
+}
+
+function hasTile(page: AntreaOverviewPage, heading: string): boolean {
+    return page.shadowRoot!.querySelector(`antrea-card[heading="${heading}"]`) !== null;
+}
+
+function alertText(page: AntreaOverviewPage, status: 'info' | 'danger'): string | null {
+    const alert = page.shadowRoot!.querySelector(`antrea-alert[status="${status}"]`);
+    return alert === null ? null : (alert.textContent ?? '').trim();
+}
+
+function listRows(page: AntreaOverviewPage, heading: string): string[][] {
+    const table = page.shadowRoot!.querySelector(`antrea-card[heading="${heading}"] table`);
+    return Array.from(table?.querySelectorAll('tbody tr') ?? []).map(
+        row => Array.from(row.querySelectorAll('td')).map(cell => cell.textContent ?? ''),
+    );
+}
+
+describe('AntreaOverviewPage — tiles', () => {
+    test('renders a count per resource type', async () => {
+        const page = await mount({
+            namespaces: list(['default', 'kube-system']),
+            pods: list(['p1', 'p2', 'p3'], 'default'),
+            services: list(['svc1'], 'default'),
+        });
+
+        expect(tileValue(page, 'Namespaces')).toBe('2');
+        expect(tileValue(page, 'Pods')).toBe('3');
+        expect(tileValue(page, 'Services')).toBe('1');
+        expect(tileValue(page, 'Deployments')).toBe('0');
+    });
+
+    test('combines Antrea ClusterNetworkPolicy and NetworkPolicy counts into one tile', async () => {
+        const page = await mount({
+            antreaClusterNetworkPolicies: list(['acnp1']),
+            antreaNetworkPolicies: list(['anp1', 'anp2'], 'default'),
+        });
+
+        expect(tileValue(page, 'Antrea Network Policies')).toBe('3');
+    });
+
+    test('a truncated list (metadata.continue present) shows a "+" instead of a false-exact count', async () => {
+        const page = await mount({
+            pods: { items: [item('p1', 'default')], metadata: { continue: 'abc' } },
+        });
+
+        expect(tileValue(page, 'Pods')).toBe('1+');
+    });
+
+    test('a truncated list reporting remainingItemCount shows the true total, not a floor', async () => {
+        const page = await mount({
+            pods: { items: [item('p1', 'default')], metadata: { continue: 'abc', remainingItemCount: 41 } },
+        });
+
+        expect(tileValue(page, 'Pods')).toBe('42');
+    });
+
+    test('every list request carries a page limit', async () => {
+        const seenUrls: string[] = [];
+        await mountWith(async (url: string) => {
+            seenUrls.push(url);
+            const key = keyForUrl(url);
+            if (key === 'access-summary') return jsonResponse(fullAccessSummary());
+            if (key) return jsonResponse({ items: [] });
+            throw new Error(`unexpected fetch to ${url}`);
+        });
+
+        // An unlimited list would pull every Pod spec in the cluster through the proxy just to
+        // count them, and would never set metadata.continue, making the truncation handling dead.
+        const listUrls = seenUrls.filter(u => keyForUrl(u) !== 'access-summary');
+        expect(listUrls.length).toBeGreaterThan(0);
+        for (const url of listUrls) {
+            expect(new URL(url, 'http://localhost').searchParams.get('limit')).toBe('500');
+        }
+    });
+});
+
+describe('AntreaOverviewPage — per-resource degradation', () => {
+    test('a resource the user cannot list is skipped, not fetched, and a note is shown', async () => {
+        const summary: AccessSummary = {
+            ...fullAccessSummary(),
+            rules: {
+                resourceRules: [{ apiGroups: [''], resources: ['pods'], verbs: ['list'] }],
+                nonResourceRules: [],
+                incomplete: false,
+            },
+        };
+        const page = await mount({ pods: list(['p1'], 'default') }, summary);
+
+        expect(hasTile(page, 'Pods')).toBe(true);
+        expect(hasTile(page, 'Services')).toBe(false);
+        expect(alertText(page, 'info')).not.toBeNull();
+    });
+
+    test('one resource 403ing degrades that tile while the others still render', async () => {
+        const page = await mountWith(async (url: string) => {
+            const key = keyForUrl(url);
+            if (key === 'access-summary') return jsonResponse(fullAccessSummary());
+            if (key === 'pods') return new Response('forbidden', { status: 403 });
+            if (key) return jsonResponse({ items: [] });
+            throw new Error(`unexpected fetch to ${url}`);
+        });
+
+        expect(hasTile(page, 'Pods')).toBe(false);
+        expect(hasTile(page, 'Services')).toBe(true);
+        expect(alertText(page, 'info')).not.toBeNull();
+        // A 403 is a permissions problem, not a failure: no danger alert.
+        expect(alertText(page, 'danger')).toBeNull();
+    });
+
+    test('access-summary fetch failure fails open: every resource is fetched', async () => {
+        const page = await mount({ pods: list(['p1'], 'default') }, null);
+
+        expect(hasTile(page, 'Pods')).toBe(true);
+        expect(hasTile(page, 'Services')).toBe(true);
+        expect(alertText(page, 'info')).toBeNull();
+    });
+
+    test('a non-403 failure shows a danger alert carrying the error', async () => {
+        const page = await mountWith(async (url: string) => {
+            const key = keyForUrl(url);
+            if (key === 'access-summary') return jsonResponse(fullAccessSummary());
+            if (key === 'pods') return new Response('backend exploded', { status: 500 });
+            if (key) return jsonResponse({ items: [] });
+            throw new Error(`unexpected fetch to ${url}`);
+        });
+
+        expect(alertText(page, 'danger')).toContain('backend exploded');
+    });
+
+    test('a 401 response dispatches antrea-session-expired', async () => {
+        vi.stubGlobal('fetch', vi.fn(async () => new Response('', { status: 401 })));
+        el = document.createElement('antrea-overview-page') as AntreaOverviewPage;
+        const onSessionExpired = vi.fn();
+        el.addEventListener('antrea-session-expired', onSessionExpired);
+        document.body.appendChild(el);
+        await el.updateComplete;
+        await new Promise(r => setTimeout(r, 0));
+        await new Promise(r => setTimeout(r, 0));
+
+        expect(onSessionExpired).toHaveBeenCalledTimes(1);
+    });
+});
+
+describe('AntreaOverviewPage — namespace filter', () => {
+    test('selecting a namespace re-fetches namespaced resources scoped to it', async () => {
+        const page = await mount({
+            namespaces: list(['default', 'kube-system']),
+            pods: list(['p1', 'p2'], 'default'),
+        });
+        expect(tileValue(page, 'Pods')).toBe('2');
+
+        const seenUrls: string[] = [];
+        vi.stubGlobal('fetch', vi.fn(async (url: string) => {
+            seenUrls.push(url);
+            const key = keyForUrl(url);
+            if (key === 'access-summary') return jsonResponse(fullAccessSummary());
+            if (key === 'pods') return jsonResponse(list(['p1'], 'kube-system'));
+            return jsonResponse({ items: [] });
+        }));
+
+        const select = page.shadowRoot!.querySelector('#ns-select') as HTMLSelectElement;
+        select.value = 'kube-system';
+        select.dispatchEvent(new Event('change'));
+        await page.updateComplete;
+        await new Promise(r => setTimeout(r, 0));
+        await new Promise(r => setTimeout(r, 0));
+        await page.updateComplete;
+
+        expect(tileValue(page, 'Pods')).toBe('1');
+        expect(seenUrls.some(u => u.split('?')[0].endsWith('/api/v1/namespaces/kube-system/pods'))).toBe(true);
+    });
+
+    test('the picked namespace stays selected after the reload it triggers', async () => {
+        const page = await mount({
+            namespaces: list(['default', 'kube-system']),
+            pods: list(['p1', 'p2'], 'default'),
+        });
+
+        // The reload must be slow enough for at least one render to land while it is in flight.
+        // With instantly-resolved mocks Lit coalesces the whole reload into a single update, so
+        // the intermediate state this test is about never reaches the DOM.
+        vi.stubGlobal('fetch', vi.fn(async (url: string) => {
+            const key = keyForUrl(url);
+            await new Promise(r => setTimeout(r, 5));
+            if (key === 'access-summary') return jsonResponse(fullAccessSummary());
+            if (key === 'namespaces') return jsonResponse(list(['default', 'kube-system']));
+            return jsonResponse({ items: [] });
+        }));
+
+        const select = page.shadowRoot!.querySelector('#ns-select') as HTMLSelectElement;
+        select.value = 'kube-system';
+        select.dispatchEvent(new Event('change'));
+
+        // Render once mid-flight: this is where the old code swapped the page for a spinner.
+        await page.updateComplete;
+        for (let i = 0; i < 10; i++) await new Promise(r => setTimeout(r, 5));
+        await page.updateComplete;
+
+        // Regression: the reload used to blank the page, so the <select> was torn down and
+        // rebuilt, and its value was assigned before its options existed — silently snapping the
+        // selection back to "All Namespaces" while the counts stayed namespace-scoped.
+        const after = page.shadowRoot!.querySelector('#ns-select') as HTMLSelectElement;
+        expect(after).not.toBeNull();
+        expect(after.value).toBe('kube-system');
+    });
+});
+
+describe('AntreaOverviewPage — click-through to Service Map', () => {
+    test('clicking a Pod row dispatches antrea-navigate with a pod+namespace filter', async () => {
+        const page = await mount({ pods: list(['web-1'], 'default') });
+        const onNavigate = vi.fn();
+        page.addEventListener('antrea-navigate', onNavigate);
+
+        expect(listRows(page, 'Pods')).toEqual([['default', 'web-1']]);
+        const row = page.shadowRoot!.querySelector('antrea-card[heading="Pods"] tbody tr') as HTMLElement;
+        row.click();
+
+        expect(onNavigate).toHaveBeenCalledTimes(1);
+        const detail = (onNavigate.mock.calls[0][0] as CustomEvent).detail;
+        expect(detail).toEqual({ path: '/flows', search: { view: 'map', namespaces: 'default', pods: 'web-1' } });
+    });
+
+    test('clicking a Service row dispatches antrea-navigate with a service+namespace filter', async () => {
+        const page = await mount({ services: list(['svc1'], 'default') });
+        const onNavigate = vi.fn();
+        page.addEventListener('antrea-navigate', onNavigate);
+
+        const row = page.shadowRoot!.querySelector('antrea-card[heading="Services"] tbody tr') as HTMLElement;
+        row.click();
+
+        expect(onNavigate).toHaveBeenCalledTimes(1);
+        const detail = (onNavigate.mock.calls[0][0] as CustomEvent).detail;
+        // "namespace/name": a bare service name is dropped by destinationK8sServiceFilterKey on
+        // the Flow Visibility side, so the deep link has to carry the qualified form.
+        expect(detail).toEqual({ path: '/flows', search: { view: 'map', namespaces: 'default', services: 'default/svc1' } });
+    });
+});

--- a/client/web/antrea-ui-components/src/pages/antrea-overview-page.ts
+++ b/client/web/antrea-ui-components/src/pages/antrea-overview-page.ts
@@ -1,0 +1,371 @@
+// Copyright 2026 Antrea Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+import { html, css } from 'lit';
+import { state } from 'lit/decorators.js';
+import { pageStyles } from '../lib/styles.js';
+import { apiFetchJSON, APIError } from '../lib/api.js';
+import {
+    accessSummary, can,
+    GATE_NAMESPACES_LIST, GATE_PODS_LIST, GATE_SERVICES_LIST,
+    GATE_DEPLOYMENTS_LIST, GATE_STATEFULSETS_LIST, GATE_DAEMONSETS_LIST,
+    GATE_K8S_NETWORKPOLICIES_LIST, GATE_ANTREA_CLUSTERNETWORKPOLICIES_LIST, GATE_ANTREA_NETWORKPOLICIES_LIST,
+} from '../lib/access-api.js';
+import type { AccessSummary, ResourceQuery } from '../lib/access-api.js';
+import { SessionAwarePage } from '../lib/session-aware-page.js';
+import '../antrea-card';
+import '../antrea-alert';
+
+// ── Types ──────────────────────────────────────────────────────────────────
+
+interface K8sItem { metadata: { name: string; namespace?: string } }
+interface K8sList {
+    items: K8sItem[];
+    metadata?: {
+        /** Set when the server truncated the list at PAGE_LIMIT: there are more items. */
+        continue?: string;
+        /** How many items were left off the page. The API server sets it on a truncated list
+         * whenever it can compute it, which lets a tile show the true total from one request
+         * instead of a "N+" floor; it is absent when the count is not available. */
+        remainingItemCount?: number;
+    };
+}
+
+interface NamedItem { name: string; namespace: string }
+
+interface ResourceSpec {
+    key: string;
+    /** Used only in error messages — see TILES below for what's actually displayed. */
+    label: string;
+    gate: ResourceQuery;
+    /** Builds the k8s proxy path (see pkg/server/api/k8s.go — RBAC is the only guard, there is no
+     * path allowlist), given the selected namespace ('' meaning all namespaces / cluster scope). */
+    path: (ns: string) => string;
+}
+
+interface Tile {
+    label: string;
+    /** Multiple keys are summed into one tile — used to combine Antrea's cluster-scoped and
+     * namespaced NetworkPolicy kinds into a single "Antrea Network Policies" count. */
+    resourceKeys: string[];
+}
+
+// How many rows of the clickable Pods/Services lists to render. This is a dashboard, not a
+// resource browser: a hard cap keeps a large cluster from turning this page into an unpaginated
+// table, and the tile above already tells the user the true count.
+const LIST_ROW_LIMIT = 50;
+
+// `limit` sent on every list request. Without it the API server returns every object of the
+// kind, so counting Pods on a large cluster would pull tens of MB of Pod specs through the proxy
+// on every load of what is the landing page — and the truncation handling below would be dead
+// code, since an unlimited list is never truncated. The count stays exact as long as the server
+// reports metadata.remainingItemCount; otherwise the tile shows "N+". Kept comfortably above
+// LIST_ROW_LIMIT so the Pods/Services lists are still full pages.
+const PAGE_LIMIT = 500;
+
+/** Appends PAGE_LIMIT to a resource path. The proxy forwards the query string untouched (see
+ * pkg/server/api/k8s.go, which only rewrites the path). */
+function withPageLimit(path: string): string {
+    return `${path}?limit=${PAGE_LIMIT}`;
+}
+
+const RESOURCES: ResourceSpec[] = [
+    // The namespace <select> is built from this page, so a cluster with more than PAGE_LIMIT
+    // namespaces gets a truncated picker (the tile still shows the true total). Namespaces are
+    // the one kind where that trade-off bites; it beats an unbounded list on every other.
+    { key: 'namespaces', label: 'Namespaces', gate: GATE_NAMESPACES_LIST,
+        path: () => 'k8s/api/v1/namespaces' },
+    { key: 'pods', label: 'Pods', gate: GATE_PODS_LIST,
+        path: ns => ns ? `k8s/api/v1/namespaces/${ns}/pods` : 'k8s/api/v1/pods' },
+    { key: 'services', label: 'Services', gate: GATE_SERVICES_LIST,
+        path: ns => ns ? `k8s/api/v1/namespaces/${ns}/services` : 'k8s/api/v1/services' },
+    { key: 'deployments', label: 'Deployments', gate: GATE_DEPLOYMENTS_LIST,
+        path: ns => ns ? `k8s/apis/apps/v1/namespaces/${ns}/deployments` : 'k8s/apis/apps/v1/deployments' },
+    { key: 'statefulsets', label: 'StatefulSets', gate: GATE_STATEFULSETS_LIST,
+        path: ns => ns ? `k8s/apis/apps/v1/namespaces/${ns}/statefulsets` : 'k8s/apis/apps/v1/statefulsets' },
+    { key: 'daemonsets', label: 'DaemonSets', gate: GATE_DAEMONSETS_LIST,
+        path: ns => ns ? `k8s/apis/apps/v1/namespaces/${ns}/daemonsets` : 'k8s/apis/apps/v1/daemonsets' },
+    { key: 'k8sNetworkPolicies', label: 'K8s Network Policies', gate: GATE_K8S_NETWORKPOLICIES_LIST,
+        path: ns => ns ? `k8s/apis/networking.k8s.io/v1/namespaces/${ns}/networkpolicies` : 'k8s/apis/networking.k8s.io/v1/networkpolicies' },
+    // ClusterNetworkPolicy is cluster-scoped (no namespace concept) — the namespace filter never
+    // narrows it.
+    { key: 'antreaClusterNetworkPolicies', label: 'Antrea ClusterNetworkPolicies', gate: GATE_ANTREA_CLUSTERNETWORKPOLICIES_LIST,
+        path: () => 'k8s/apis/crd.antrea.io/v1beta1/clusternetworkpolicies' },
+    { key: 'antreaNetworkPolicies', label: 'Antrea NetworkPolicies', gate: GATE_ANTREA_NETWORKPOLICIES_LIST,
+        path: ns => ns ? `k8s/apis/crd.antrea.io/v1beta1/namespaces/${ns}/networkpolicies` : 'k8s/apis/crd.antrea.io/v1beta1/networkpolicies' },
+];
+
+const TILES: Tile[] = [
+    { label: 'Namespaces', resourceKeys: ['namespaces'] },
+    { label: 'Pods', resourceKeys: ['pods'] },
+    { label: 'Services', resourceKeys: ['services'] },
+    { label: 'Deployments', resourceKeys: ['deployments'] },
+    { label: 'StatefulSets', resourceKeys: ['statefulsets'] },
+    { label: 'DaemonSets', resourceKeys: ['daemonsets'] },
+    { label: 'K8s Network Policies', resourceKeys: ['k8sNetworkPolicies'] },
+    { label: 'Antrea Network Policies', resourceKeys: ['antreaClusterNetworkPolicies', 'antreaNetworkPolicies'] },
+];
+
+// ── Component ────────────────────────────────────────────────────────────────
+
+export class AntreaOverviewPage extends SessionAwarePage {
+    static styles = [pageStyles, css`
+        .stat-grid {
+            display: grid;
+            grid-template-columns: repeat(auto-fill, minmax(160px, 1fr));
+            gap: var(--antrea-space-md, 1rem);
+        }
+        /* Every tile is the height of the tallest one in its row, so a two-line heading like
+           "K8s Network Policies" doesn't leave its neighbours short. Grid items already stretch;
+           this passes that height down to antrea-card's internal wrapper. */
+        .stat-grid antrea-card { height: 100%; }
+        .stat-value {
+            font-size: 2rem;
+            font-weight: var(--antrea-font-weight-bold, 600);
+            color: var(--antrea-color-primary, #0079b8);
+            text-align: center;
+        }
+        /* A re-filter leaves the previous numbers on screen; dim them so they don't read as
+           current while the new ones are still loading. */
+        .stale { opacity: 0.5; }
+        /* Keeps the page-layout spacing between the two list cards, which are wrapped in one
+           element so a single class can dim them together. */
+        .list-stack {
+            display: flex;
+            flex-direction: column;
+            gap: 1.5rem;
+        }
+        .clickable-row { cursor: pointer; }
+        .clickable-row:hover { background: var(--antrea-color-bg-hover, #2e3f4d); }
+    `];
+
+    @state() private _namespace = '';
+    @state() private _namespaces: string[] = [];
+    @state() private _loading = true;
+    // Set while a re-filter is in flight. Unlike _loading it does not blank the page; the tiles
+    // stay visible (dimmed) so the namespace <select> survives the update.
+    @state() private _refreshing = false;
+    @state() private _counts: Record<string, number> = {};
+    @state() private _truncated: Record<string, boolean> = {};
+    @state() private _pods: NamedItem[] = [];
+    @state() private _services: NamedItem[] = [];
+    // See antrea-summary-page.ts for why these two are tracked (and reported) separately: one
+    // means "the UI is hiding something the user isn't allowed to see", the other means "a call
+    // the user IS allowed to make failed for some other reason".
+    @state() private _someCardsForbidden = false;
+    @state() private _cardErrors: string[] = [];
+
+    private _accessSummary: AccessSummary | null = null;
+    // Whether a load has already completed, so a re-filter can keep the page rendered.
+    private _loadedOnce = false;
+    // Bumped before each _loadCounts() and captured per-call, so a response from a superseded
+    // call (e.g. the namespace filter changed again before the first fetch returned) can't
+    // overwrite state after a newer one has already resolved.
+    private _loadGeneration = 0;
+
+    protected override async onSessionReady() {
+        let summary: AccessSummary | null;
+        try {
+            summary = await accessSummary();
+        } catch {
+            summary = null;
+        }
+        this._accessSummary = summary;
+        await this._loadCounts();
+    }
+
+    private _onNamespaceChange(e: Event) {
+        this._namespace = (e.target as HTMLSelectElement).value;
+        this._loadCounts();
+    }
+
+    private async _loadCounts() {
+        const generation = ++this._loadGeneration;
+        // Only the very first load blanks the page for a spinner. A namespace re-filter keeps the
+        // rendered page up and just marks it stale: tearing the page down mid-interaction would
+        // destroy the <select> the user is interacting with, and rebuilding it resets its
+        // selection (a fresh <select> has no options at the moment its value is assigned).
+        if (this._loadedOnce) this._refreshing = true;
+        else this._loading = true;
+        this._someCardsForbidden = false;
+        this._cardErrors = [];
+        const summary = this._accessSummary;
+
+        const results = await Promise.allSettled(RESOURCES.map(r =>
+            can(summary, r.gate)
+                ? apiFetchJSON<K8sList>(withPageLimit(r.path(this._namespace)))
+                : Promise.reject(new Error('skipped: no permission')),
+        ));
+        if (generation !== this._loadGeneration) return;
+
+        for (const result of results) {
+            if (result.status === 'rejected' && this.isSessionExpiredError(result.reason)) {
+                this.dispatchSessionExpired();
+                return;
+            }
+        }
+
+        const counts: Record<string, number> = {};
+        const truncated: Record<string, boolean> = {};
+        // Keeps the previous namespace list (and thus the dropdown) intact for a user who can't
+        // list namespaces themselves but can read other resources scoped by one.
+        let namespaces = this._namespaces;
+        let pods: NamedItem[] = [];
+        let services: NamedItem[] = [];
+
+        RESOURCES.forEach((r, i) => {
+            if (!can(summary, r.gate)) {
+                this._someCardsForbidden = true;
+                return;
+            }
+            const result = results[i];
+            if (result.status === 'fulfilled') {
+                // A page plus the count of what was left off it is the true total. Only when the
+                // server truncated without reporting that remainder is the count a floor.
+                const remaining = result.value.metadata?.remainingItemCount;
+                counts[r.key] = result.value.items.length + (remaining ?? 0);
+                truncated[r.key] = Boolean(result.value.metadata?.continue) && remaining === undefined;
+                if (r.key === 'namespaces') {
+                    namespaces = result.value.items.map(it => it.metadata.name).sort();
+                } else if (r.key === 'pods') {
+                    pods = result.value.items.map(it => ({ name: it.metadata.name, namespace: it.metadata.namespace ?? '' }));
+                } else if (r.key === 'services') {
+                    services = result.value.items.map(it => ({ name: it.metadata.name, namespace: it.metadata.namespace ?? '' }));
+                }
+            } else {
+                this._recordFailure(r.label, result.reason);
+            }
+        });
+
+        this._counts = counts;
+        this._truncated = truncated;
+        this._namespaces = namespaces;
+        this._pods = pods;
+        this._services = services;
+        this._loading = false;
+        this._refreshing = false;
+        this._loadedOnce = true;
+    }
+
+    /** Classifies a failed fetch the gate had allowed. A 403 means the access summary was wrong
+     * (stale, incomplete, or fail-open) and the resource really is forbidden; anything else is a
+     * genuine error and must be surfaced as one, with its message. */
+    private _recordFailure(label: string, reason: unknown) {
+        if (reason instanceof APIError && reason.code === 403) {
+            this._someCardsForbidden = true;
+            return;
+        }
+        const message = reason instanceof Error ? reason.message : String(reason);
+        this._cardErrors = [...this._cardErrors, `${label}: ${message}`];
+    }
+
+    /** Tells the host to route to the Flow Visibility Service Map with a filter preset — the
+     * host owns routing (React Router), this component does not, so it hands off via an event
+     * the same way antrea-session-expired does. Array values are comma-joined to match the query
+     * param convention the Flow Visibility page's own filters already use. */
+    private _navigateToServiceMap(filter: { namespaces?: string[]; podNames?: string[]; serviceNames?: string[] }) {
+        const search: Record<string, string> = { view: 'map' };
+        if (filter.namespaces?.length) search.namespaces = filter.namespaces.join(',');
+        if (filter.podNames?.length) search.pods = filter.podNames.join(',');
+        if (filter.serviceNames?.length) search.services = filter.serviceNames.join(',');
+        this.dispatchEvent(new CustomEvent('antrea-navigate', { detail: { path: '/flows', search }, bubbles: true, composed: true }));
+    }
+
+    private _renderTile(tile: Tile) {
+        const present = tile.resourceKeys.filter(k => k in this._counts);
+        if (present.length === 0) return '';
+        const count = present.reduce((sum, k) => sum + this._counts[k], 0);
+        const isTruncated = present.some(k => this._truncated[k]);
+        return html`
+            <antrea-card heading=${tile.label}>
+                <div class="stat-value">${count}${isTruncated ? '+' : ''}</div>
+            </antrea-card>
+        `;
+    }
+
+    private _renderClickableList(heading: string, resourceKey: string, items: NamedItem[], onClick: (item: NamedItem) => void) {
+        if (items.length === 0) return '';
+        // items is one page of at most PAGE_LIMIT, so its length is not the total — report the
+        // tile's count instead, with the same "+" the tile uses when even that is a floor.
+        const total = `${this._counts[resourceKey] ?? items.length}${this._truncated[resourceKey] ? '+' : ''}`;
+        return html`
+            <antrea-card heading=${heading}>
+                <table class="data-table" part="table">
+                    <thead><tr><th part="table-header-cell">Namespace</th><th part="table-header-cell">Name</th></tr></thead>
+                    <tbody>
+                        ${items.slice(0, LIST_ROW_LIMIT).map(item => html`
+                            <tr class="clickable-row" @click=${() => onClick(item)}>
+                                <td part="table-cell">${item.namespace}</td>
+                                <td part="table-cell">${item.name}</td>
+                            </tr>
+                        `)}
+                    </tbody>
+                </table>
+                ${items.length > LIST_ROW_LIMIT ? html`<div class="text-muted">Showing first ${LIST_ROW_LIMIT} of ${total}</div>` : ''}
+            </antrea-card>
+        `;
+    }
+
+    override render() {
+        if (this._loading) {
+            return html`<main><div class="loading-row"><span class="spinner"></span><span>Loading…</span></div></main>`;
+        }
+
+        return html`
+            <main>
+                <div class="page-layout">
+                    <p class="page-title">Overview</p>
+                    ${this._someCardsForbidden ? html`
+                        <antrea-alert status="info">
+                            Some information is not shown because your account does not have permission to view it.
+                        </antrea-alert>
+                    ` : ''}
+                    ${this._cardErrors.length > 0 ? html`
+                        <antrea-alert status="danger">
+                            ${this._cardErrors.join('; ')}
+                        </antrea-alert>
+                    ` : ''}
+
+                    ${this._namespaces.length > 0 ? html`
+                        <div class="row">
+                            <label class="field-label" for="ns-select">Namespace</label>
+                            <!-- ?selected on each option rather than .value on the <select>: a
+                                 property binding is committed while the option list may still be
+                                 empty, which silently resets the selection to the first entry. -->
+                            <select id="ns-select" class="field-select" style="max-width:240px" @change=${this._onNamespaceChange}>
+                                <option value="" ?selected=${this._namespace === ''}>All Namespaces</option>
+                                ${this._namespaces.map(ns => html`<option value=${ns} ?selected=${ns === this._namespace}>${ns}</option>`)}
+                            </select>
+                        </div>
+                    ` : ''}
+
+                    <div class="stat-grid ${this._refreshing ? 'stale' : ''}">
+                        ${TILES.map(tile => this._renderTile(tile))}
+                    </div>
+
+                    <div class="list-stack ${this._refreshing ? 'stale' : ''}">
+                        ${this._renderClickableList('Pods', 'pods', this._pods, p => this._navigateToServiceMap({ namespaces: [p.namespace], podNames: [p.name] }))}
+                        ${this._renderClickableList('Services', 'services', this._services, s => this._navigateToServiceMap({ namespaces: [s.namespace], serviceNames: [`${s.namespace}/${s.name}`] }))}
+                    </div>
+                </div>
+            </main>
+        `;
+    }
+}
+
+customElements.define('antrea-overview-page', AntreaOverviewPage);
+
+declare global {
+    interface HTMLElementTagNameMap { 'antrea-overview-page': AntreaOverviewPage; }
+}

--- a/client/web/antrea-ui-plugin-sdk/src/index.ts
+++ b/client/web/antrea-ui-plugin-sdk/src/index.ts
@@ -60,6 +60,18 @@ export interface PluginSidebarEntry {
     icon?: string;
 }
 
+/** A tab a plugin wants added to the Overview landing page, alongside the built-in "Overview"
+ * tab — e.g. the ANS plugin's "Security" tab. `tag` is the custom element the plugin's entry
+ * module registers via customElements.define(...); the host mounts it the same way it mounts
+ * the built-in Overview tab, with the same session-expiry wiring. `id` must not be "overview"
+ * (reserved for the built-in tab) or collide with another plugin's tab id — the host drops (and
+ * logs) whichever registration loses the race. */
+export interface LandingPageTab {
+    id: string;
+    label: string;
+    tag: string;
+}
+
 // Kept in sync by hand with the identically-named interface in antrea-ui/src/plugins.ts, which
 // is what actually populates window.__antreaPluginHost — this side only needs to describe its
 // shape well enough to type-check the wrapper functions below.
@@ -68,6 +80,7 @@ export interface AntreaPluginHost {
     registerSidebarEntry(entry: PluginSidebarEntry): void;
     registerEdgeExtraRenderer(fn: EdgeExtraRenderer): void;
     registerFlowTableColumnsProcessor(fn: FlowTableColumnsProcessor): void;
+    registerLandingPageTab(tab: LandingPageTab): void;
 }
 
 declare global {
@@ -106,4 +119,9 @@ export function registerEdgeExtraRenderer(fn: EdgeExtraRenderer): void {
  * column list (built-ins plus any earlier plugin's additions) and returns the new list. */
 export function registerFlowTableColumnsProcessor(fn: FlowTableColumnsProcessor): void {
     host().registerFlowTableColumnsProcessor(fn);
+}
+
+/** Adds a tab to the Overview landing page, rendering `tab.tag`'s custom element when selected. */
+export function registerLandingPageTab(tab: LandingPageTab): void {
+    host().registerLandingPageTab(tab);
 }

--- a/client/web/antrea-ui/src/access.test.tsx
+++ b/client/web/antrea-ui/src/access.test.tsx
@@ -150,6 +150,7 @@ describe('HomeRedirect', () => {
                     <MemoryRouter initialEntries={['/']}>
                         <Routes>
                             <Route path="/" element={<HomeRedirect />} />
+                            <Route path="/overview" element={<div data-testid="landed">overview</div>} />
                             <Route path="/summary" element={<div data-testid="landed">summary</div>} />
                             <Route path="/traceflow" element={<div data-testid="landed">traceflow</div>} />
                             <Route path="/flows" element={<div data-testid="landed">flows</div>} />
@@ -159,6 +160,13 @@ describe('HomeRedirect', () => {
             </Provider>,
         );
     }
+
+    test('lands on /overview when canViewOverview is granted', async () => {
+        renderAt(summaryWith({
+            rules: { resourceRules: [{ apiGroups: [''], resources: ['pods'], verbs: ['list'] }], nonResourceRules: [], incomplete: false },
+        }));
+        await waitFor(() => expect(document.querySelector('[data-testid="landed"]')?.textContent).toBe('overview'));
+    });
 
     test('lands on /summary when canViewSummary is granted', async () => {
         renderAt(summaryWith({
@@ -179,8 +187,8 @@ describe('HomeRedirect', () => {
         await waitFor(() => expect(document.querySelector('[data-testid="landed"]')?.textContent).toBe('flows'));
     });
 
-    test('fails open to /summary when the fetch fails', async () => {
+    test('fails open to /overview when the fetch fails', async () => {
         renderAt(null);
-        await waitFor(() => expect(document.querySelector('[data-testid="landed"]')?.textContent).toBe('summary'));
+        await waitFor(() => expect(document.querySelector('[data-testid="landed"]')?.textContent).toBe('overview'));
     });
 });

--- a/client/web/antrea-ui/src/antrea-components.d.ts
+++ b/client/web/antrea-ui/src/antrea-components.d.ts
@@ -16,7 +16,7 @@
 // Allows using <antrea-button>, <antrea-input>, etc. in TSX files without
 // TypeScript errors, and provides prop type checking.
 
-import type { AntreaButton, AntreaAlert, AntreaCard, AntreaNav, AntreaNavItem, AntreaInput, EdgeExtraRenderer, FlowTableColumnsProcessor } from '@antrea/ui-components';
+import type { AntreaButton, AntreaAlert, AntreaCard, AntreaNav, AntreaNavItem, AntreaInput, EdgeExtraRenderer, FlowTableColumnsProcessor, FlowVisibilityInitialFilter } from '@antrea/ui-components';
 import React from 'react';
 
 type ButtonAction = 'solid' | 'outline' | 'flat';
@@ -58,11 +58,13 @@ declare global {
             // Page components take no auth prop: they authenticate with the session cookie,
             // which the browser attaches by itself.
             'antrea-summary-page': React.HTMLAttributes<HTMLElement> & React.ClassAttributes<HTMLElement>;
+            'antrea-overview-page': React.HTMLAttributes<HTMLElement> & React.ClassAttributes<HTMLElement>;
             'antrea-settings-page': React.HTMLAttributes<HTMLElement> & React.ClassAttributes<HTMLElement>;
             'antrea-traceflow-page': React.HTMLAttributes<HTMLElement> & React.ClassAttributes<HTMLElement>;
             'antrea-flow-visibility-page': React.HTMLAttributes<HTMLElement> & React.ClassAttributes<HTMLElement> & {
                 edgeExtraRenderers?: EdgeExtraRenderer[];
                 flowTableColumnsProcessors?: FlowTableColumnsProcessor[];
+                initialFilter?: FlowVisibilityInitialFilter;
             };
             'antrea-login-page': React.HTMLAttributes<HTMLElement> & React.ClassAttributes<HTMLElement>;
         }

--- a/client/web/antrea-ui/src/index.tsx
+++ b/client/web/antrea-ui/src/index.tsx
@@ -21,7 +21,7 @@ import { RouterProvider } from 'react-router/dom';
 import { setApiBase } from '@antrea/ui-components';
 import './index.css';
 import App from './App';
-import { SummaryPage, TraceflowPage, FlowVisibilityPage, SettingsPage, PluginPage, HomeRedirect } from './pages';
+import { OverviewPage, SummaryPage, TraceflowPage, FlowVisibilityPage, SettingsPage, PluginPage, HomeRedirect } from './pages';
 import reportWebVitals from './reportWebVitals';
 import config from './config';
 import { loadPlugins, getPluginRoutes, getPluginSidebarEntries } from './plugins';
@@ -47,6 +47,10 @@ async function main() {
                 {
                     index: true,
                     element: <HomeRedirect />,
+                },
+                {
+                    path: "overview",
+                    element: <OverviewPage />,
                 },
                 {
                     path: "summary",

--- a/client/web/antrea-ui/src/nav.test.tsx
+++ b/client/web/antrea-ui/src/nav.test.tsx
@@ -88,6 +88,7 @@ describe('NavTab — permission gating', () => {
         mockUseAccess.mockReturnValue({ summary: null, loaded: false });
         render(<NavTab pluginSidebarEntries={[]} />, { wrapper: MemoryRouter });
 
+        expect(document.querySelector('a[href="/overview"]')).toBeNull();
         expect(document.querySelector('a[href="/summary"]')).toBeNull();
         expect(document.querySelector('a[href="/traceflow"]')).toBeNull();
         // Flow Visibility and Settings have no per-user RBAC, so they are not gated on load.
@@ -95,10 +96,11 @@ describe('NavTab — permission gating', () => {
         expect(document.querySelector('a[href="/settings"]')).not.toBeNull();
     });
 
-    test('a null summary (fetch failed) fails open: both core tabs show', () => {
+    test('a null summary (fetch failed) fails open: all core tabs show', () => {
         mockUseAccess.mockReturnValue({ summary: null, loaded: true });
         render(<NavTab pluginSidebarEntries={[]} />, { wrapper: MemoryRouter });
 
+        expect(document.querySelector('a[href="/overview"]')).not.toBeNull();
         expect(document.querySelector('a[href="/summary"]')).not.toBeNull();
         expect(document.querySelector('a[href="/traceflow"]')).not.toBeNull();
     });
@@ -121,5 +123,25 @@ describe('NavTab — permission gating', () => {
         render(<NavTab pluginSidebarEntries={[]} />, { wrapper: MemoryRouter });
 
         expect(document.querySelector('a[href="/summary"]')).toBeNull();
+    });
+
+    test('Overview shows when the user can list Pods, even without Summary permissions', () => {
+        mockUseAccess.mockReturnValue({
+            summary: summaryAllowing({
+                resourceRules: [{ apiGroups: [''], resources: ['pods'], verbs: ['list'] }],
+            }),
+            loaded: true,
+        });
+        render(<NavTab pluginSidebarEntries={[]} />, { wrapper: MemoryRouter });
+
+        expect(document.querySelector('a[href="/overview"]')).not.toBeNull();
+        expect(document.querySelector('a[href="/summary"]')).toBeNull();
+    });
+
+    test('Overview is hidden when none of its inventory gates is granted', () => {
+        mockUseAccess.mockReturnValue({ summary: summaryAllowing(), loaded: true });
+        render(<NavTab pluginSidebarEntries={[]} />, { wrapper: MemoryRouter });
+
+        expect(document.querySelector('a[href="/overview"]')).toBeNull();
     });
 });

--- a/client/web/antrea-ui/src/nav.tsx
+++ b/client/web/antrea-ui/src/nav.tsx
@@ -18,14 +18,23 @@ import React from 'react';
 import { useLocation } from 'react-router';
 import { Link } from 'react-router';
 import '@antrea/ui-components';
-import { can, canViewSummary, GATE_TRACEFLOW_CREATE } from '@antrea/ui-components';
+import { can, canViewSummary, canViewOverview, GATE_TRACEFLOW_CREATE } from '@antrea/ui-components';
 import type { PluginSidebarEntry } from './plugins';
 import { useAccess } from './access';
 
-function DashboardIcon() {
+function OverviewIcon() {
     return (
         <svg width="16" height="16" viewBox="0 0 16 16" fill="currentColor" aria-hidden="true" style={{ flexShrink: 0 }}>
             <path d="M1 2a1 1 0 0 1 1-1h5a1 1 0 0 1 1 1v5a1 1 0 0 1-1 1H2a1 1 0 0 1-1-1V2zm8-1h5a1 1 0 0 1 1 1v5a1 1 0 0 1-1 1H9a1 1 0 0 1-1-1V2a1 1 0 0 1 1-1zM1 9a1 1 0 0 1 1-1h5a1 1 0 0 1 1 1v5a1 1 0 0 1-1 1H2a1 1 0 0 1-1-1V9zm8-1h5a1 1 0 0 1 1 1v5a1 1 0 0 1-1 1H9a1 1 0 0 1-1-1V9a1 1 0 0 1 1-1z"/>
+        </svg>
+    );
+}
+
+function InfoIcon() {
+    return (
+        <svg width="16" height="16" viewBox="0 0 16 16" fill="currentColor" aria-hidden="true" style={{ flexShrink: 0 }}>
+            <path d="M8 15A7 7 0 1 1 8 1a7 7 0 0 1 0 14zm0 1A8 8 0 1 0 8 0a8 8 0 0 0 0 16z"/>
+            <path d="M8.93 6.588l-2.29.287-.082.38.45.083c.294.07.352.176.288.469l-.738 3.468c-.194.897.105 1.319.808 1.319.545 0 1.178-.252 1.465-.598l.088-.416c-.2.176-.492.246-.686.246-.275 0-.375-.193-.304-.533L8.93 6.588zM9 4.5a1 1 0 1 1-2 0 1 1 0 0 1 2 0z"/>
         </svg>
     );
 }
@@ -65,15 +74,24 @@ export default function NavTab({ pluginSidebarEntries }: { pluginSidebarEntries:
 
     // While the access summary hasn't loaded yet, render no core items: entries popping in once
     // loaded reads better than entries vanishing if the answer turns out to restrict something.
+    const showOverview = loaded && canViewOverview(summary);
     const showSummary = loaded && canViewSummary(summary);
     const showTraceflow = loaded && can(summary, GATE_TRACEFLOW_CREATE);
 
     return (
         <antrea-nav>
+            {showOverview && (
+                <antrea-nav-item {...(pathname === '/overview' || pathname === '/' ? { active: true } : {})}>
+                    <Link to="/overview">
+                        <OverviewIcon />
+                        <span className="nav-label">Overview</span>
+                    </Link>
+                </antrea-nav-item>
+            )}
             {showSummary && (
-                <antrea-nav-item {...(pathname === '/summary' || pathname === '/' ? { active: true } : {})}>
+                <antrea-nav-item {...(pathname === '/summary' ? { active: true } : {})}>
                     <Link to="/summary">
-                        <DashboardIcon />
+                        <InfoIcon />
                         <span className="nav-label">Summary</span>
                     </Link>
                 </antrea-nav-item>

--- a/client/web/antrea-ui/src/pages.tsx
+++ b/client/web/antrea-ui/src/pages.tsx
@@ -14,21 +14,22 @@
  * limitations under the License.
  */
 
-import React, { useRef, useCallback } from 'react';
+import React, { useRef, useCallback, useMemo } from 'react';
 import '@antrea/ui-components';
-import { can, canViewSummary, GATE_TRACEFLOW_CREATE } from '@antrea/ui-components';
-import type { AccessSummary } from '@antrea/ui-components';
-import { Navigate } from 'react-router';
+import { can, canViewSummary, canViewOverview, GATE_TRACEFLOW_CREATE } from '@antrea/ui-components';
+import type { AccessSummary, FlowVisibilityInitialFilter } from '@antrea/ui-components';
+import { Navigate, useNavigate, useSearchParams } from 'react-router';
 import { useLogout } from './logout';
-import { getEdgeExtraRenderers, getFlowTableColumnsProcessors } from './plugins';
+import { getEdgeExtraRenderers, getFlowTableColumnsProcessors, getLandingPageTabs } from './plugins';
 import { useAccess } from './access';
 
 // Picks the first route the user is actually permitted to see, so a partially-authorized user
-// doesn't land on a Summary page that's just going to show the permission panel. While the
-// access summary hasn't loaded yet, renders nothing.
+// doesn't land on a page that's just going to show the permission panel. While the access
+// summary hasn't loaded yet, renders nothing.
 export function HomeRedirect() {
     const { summary, loaded } = useAccess();
     if (!loaded) return null;
+    if (canViewOverview(summary)) return <Navigate to="/overview" replace />;
     if (canViewSummary(summary)) return <Navigate to="/summary" replace />;
     if (can(summary, GATE_TRACEFLOW_CREATE)) return <Navigate to="/traceflow" replace />;
     // Flow Visibility has no per-user RBAC today (see docs/authentication.md), so it is always
@@ -53,7 +54,12 @@ function RequirePermission({ predicate, children }: { predicate: (s: AccessSumma
     return <>{children}</>;
 }
 
-function useLitPage() {
+// extraEvent/extraHandler let a page wire up one more DOM CustomEvent alongside
+// antrea-session-expired (e.g. Overview's antrea-navigate) through the same callback ref,
+// instead of every such page hand-rolling its own attach/detach bookkeeping. extraHandler must
+// be stable (wrap it in useCallback) — its identity is a ref-callback dependency, so a new
+// function every render would detach and reattach on every render.
+function useLitPage(extraEvent?: string, extraHandler?: EventListener) {
     const logout = useLogout();
     const attachedTo = useRef<HTMLElement | null>(null);
 
@@ -75,12 +81,66 @@ function useLitPage() {
     // ref.current going from null to the element. A callback ref fires exactly when React
     // attaches or detaches the DOM node, regardless of which component's render caused it.
     const ref = useCallback((el: HTMLElement | null) => {
-        if (attachedTo.current) attachedTo.current.removeEventListener('antrea-session-expired', onSessionExpired);
+        if (attachedTo.current) {
+            attachedTo.current.removeEventListener('antrea-session-expired', onSessionExpired);
+            if (extraEvent && extraHandler) attachedTo.current.removeEventListener(extraEvent, extraHandler);
+        }
         attachedTo.current = el;
-        if (el) el.addEventListener('antrea-session-expired', onSessionExpired);
-    }, [onSessionExpired]);
+        if (el) {
+            el.addEventListener('antrea-session-expired', onSessionExpired);
+            if (extraEvent && extraHandler) el.addEventListener(extraEvent, extraHandler);
+        }
+    }, [onSessionExpired, extraEvent, extraHandler]);
 
     return { ref };
+}
+
+interface OverviewTab { id: string; label: string; tag?: string; }
+
+export function OverviewPage() {
+    const navigate = useNavigate();
+    const [searchParams, setSearchParams] = useSearchParams();
+
+    // The Overview Lit component owns no routing of its own (see antrea-overview-page.ts's
+    // _navigateToServiceMap) — it hands off via this event the same way every page hands off a
+    // dead session, and this is where that hand-off actually calls into React Router.
+    const onNavigate = useCallback((e: Event) => {
+        const detail = (e as CustomEvent<{ path: string; search?: Record<string, string> }>).detail;
+        if (!detail) return;
+        const query = detail.search ? `?${new URLSearchParams(detail.search).toString()}` : '';
+        navigate(`${detail.path}${query}`);
+    }, [navigate]);
+    const { ref } = useLitPage('antrea-navigate', onNavigate);
+
+    // Plugin tabs (e.g. ANS's "Security") are registered once at startup (see plugins.ts) and
+    // never change afterward, so this only needs to run once per mount.
+    const tabs: OverviewTab[] = useMemo(() => [{ id: 'overview', label: 'Overview' }, ...getLandingPageTabs()], []);
+    const activeTab = tabs.find(t => t.id === searchParams.get('tab')) ?? tabs[0];
+
+    return (
+        <RequirePermission predicate={canViewOverview}>
+            <div className="page-layout">
+                {tabs.length > 1 && (
+                    <div className="btn-group">
+                        {tabs.map(tab => (
+                            <React.Fragment key={tab.id}>
+                                <antrea-button
+                                    type="button"
+                                    action={tab.id === activeTab.id ? 'solid' : 'outline'}
+                                    onClick={() => setSearchParams(tab.id === 'overview' ? {} : { tab: tab.id })}
+                                >
+                                    {tab.label}
+                                </antrea-button>
+                            </React.Fragment>
+                        ))}
+                    </div>
+                )}
+                {activeTab.id === 'overview'
+                    ? <antrea-overview-page ref={ref} />
+                    : React.createElement(activeTab.tag as string, { ref })}
+            </div>
+        </RequirePermission>
+    );
 }
 
 export function SummaryPage() {
@@ -103,11 +163,36 @@ export function TraceflowPage() {
 
 export function FlowVisibilityPage() {
     const { ref } = useLitPage();
+    const [searchParams] = useSearchParams();
+
+    // Lets the Overview landing page deep-link here with a filter preset (see
+    // antrea-overview-page.ts's _navigateToServiceMap) — undefined when none of these params are
+    // present, so a plain /flows visit is unaffected. Comma-joined, matching the convention the
+    // flow stream's own namespaces/pods/services query params already use (see
+    // pkg/handlers/flowstream/handler.go's splitTrimmed).
+    const initialFilter = useMemo<FlowVisibilityInitialFilter | undefined>(() => {
+        const namespaces = searchParams.get('namespaces');
+        const pods = searchParams.get('pods');
+        const services = searchParams.get('services');
+        const view = searchParams.get('view');
+        if (!namespaces && !pods && !services && !view) return undefined;
+        return {
+            namespaces: namespaces ? namespaces.split(',').filter(Boolean) : undefined,
+            podNames: pods ? pods.split(',').filter(Boolean) : undefined,
+            serviceNames: services ? services.split(',').filter(Boolean) : undefined,
+            viewMode: view === 'map' ? 'map' : view === 'list' ? 'list' : undefined,
+        };
+        // The Lit component only ever applies the first non-undefined value it sees (see
+        // antrea-flow-visibility-page.ts's initialFilter handling), so recomputing this on every
+        // searchParams change is harmless — it's just not read again after that first apply.
+    }, [searchParams]);
+
     return (
         <antrea-flow-visibility-page
             ref={ref}
             edgeExtraRenderers={getEdgeExtraRenderers()}
             flowTableColumnsProcessors={getFlowTableColumnsProcessors()}
+            initialFilter={initialFilter}
         />
     );
 }

--- a/client/web/antrea-ui/src/plugins.test.ts
+++ b/client/web/antrea-ui/src/plugins.test.ts
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-import { loadPlugins, dedupeByPath, getPluginRoutes, type PluginManifest, type PluginRoute } from './plugins';
+import { loadPlugins, dedupeByPath, getPluginRoutes, getLandingPageTabs, type PluginManifest, type PluginRoute, type LandingPageTab } from './plugins';
 
 function jsonResponse(body: unknown, status = 200): Response {
     return new Response(JSON.stringify(body), { status });
@@ -84,5 +84,31 @@ describe('getPluginRoutes / window.__antreaPluginHost', () => {
         window.__antreaPluginHost!.registerRoute({ path: '/plugin/test-registration', tag: 'antrea-plugin-test-registration' } satisfies PluginRoute);
 
         expect(getPluginRoutes()).toContainEqual({ path: '/plugin/test-registration', tag: 'antrea-plugin-test-registration' });
+    });
+});
+
+describe('getLandingPageTabs / window.__antreaPluginHost', () => {
+    test('registerLandingPageTab makes the tab show up in getLandingPageTabs', () => {
+        const tab: LandingPageTab = { id: 'security-test-registration', label: 'Security', tag: 'antrea-security-test-registration' };
+        window.__antreaPluginHost!.registerLandingPageTab(tab);
+
+        expect(getLandingPageTabs()).toContainEqual(tab);
+    });
+
+    test('a tab id colliding with the built-in Overview tab is dropped', () => {
+        const errorSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
+        window.__antreaPluginHost!.registerLandingPageTab({ id: 'overview', label: 'Fake Overview', tag: 'antrea-fake-overview' });
+
+        expect(getLandingPageTabs().find(t => t.id === 'overview')).toBeUndefined();
+        expect(errorSpy).toHaveBeenCalledWith(expect.stringContaining('collides with the built-in Overview tab'));
+    });
+
+    test('a tab id already claimed by an earlier plugin is dropped', () => {
+        const errorSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
+        window.__antreaPluginHost!.registerLandingPageTab({ id: 'dup-tab', label: 'First', tag: 'antrea-first' });
+        window.__antreaPluginHost!.registerLandingPageTab({ id: 'dup-tab', label: 'Second', tag: 'antrea-second' });
+
+        expect(getLandingPageTabs().filter(t => t.id === 'dup-tab')).toEqual([{ id: 'dup-tab', label: 'First', tag: 'antrea-first' }]);
+        expect(errorSpy).toHaveBeenCalledWith(expect.stringContaining('already claimed by another plugin'));
     });
 });

--- a/client/web/antrea-ui/src/plugins.ts
+++ b/client/web/antrea-ui/src/plugins.ts
@@ -41,14 +41,15 @@ import type { EdgeExtraRenderer, FlowTableColumnsProcessor } from '@antrea/ui-co
 // registerX() call goes through), but only as types — importing them with `import type` here
 // costs nothing at runtime, so there's no reason to hand-duplicate the interface as the actual
 // host-side implementation used to.
-import type { AntreaPluginHost, PluginRoute, PluginSidebarEntry } from '@antrea/ui-plugin-sdk';
+import type { AntreaPluginHost, PluginRoute, PluginSidebarEntry, LandingPageTab } from '@antrea/ui-plugin-sdk';
 
-export type { PluginRoute, PluginSidebarEntry };
+export type { PluginRoute, PluginSidebarEntry, LandingPageTab };
 
 const pluginRoutes: PluginRoute[] = [];
 const pluginSidebarEntries: PluginSidebarEntry[] = [];
 const edgeExtraRenderers: EdgeExtraRenderer[] = [];
 const flowTableColumnsProcessors: FlowTableColumnsProcessor[] = [];
+const pluginLandingPageTabs: LandingPageTab[] = [];
 
 declare global {
     interface Window { __antreaPluginHost?: AntreaPluginHost; }
@@ -59,12 +60,17 @@ window.__antreaPluginHost = {
     registerSidebarEntry: entry => pluginSidebarEntries.push(entry),
     registerEdgeExtraRenderer: fn => edgeExtraRenderers.push(fn),
     registerFlowTableColumnsProcessor: fn => flowTableColumnsProcessors.push(fn),
+    registerLandingPageTab: tab => pluginLandingPageTabs.push(tab),
 };
 
 // Top-level routes owned by Antrea UI itself. A plugin's route/sidebar entry path must not
 // collide with these — react-router's behavior with two children registered under the same
 // path is undefined, and a colliding plugin could silently shadow a built-in page.
-const RESERVED_PATHS = new Set(['', 'summary', 'traceflow', 'flows', 'settings']);
+const RESERVED_PATHS = new Set(['', 'overview', 'summary', 'traceflow', 'flows', 'settings']);
+
+// The Overview landing page's built-in tab id. A plugin's landing page tab must not collide with
+// this, for the same reason a route/sidebar entry must not collide with RESERVED_PATHS above.
+const RESERVED_LANDING_PAGE_TAB_IDS = new Set(['overview']);
 
 // A plugin's route/sidebar entry path must also not fall under this prefix: nginx proxies it
 // straight to the backend (see /api/v1/plugins/ above), so a hard refresh or direct link to
@@ -105,6 +111,31 @@ export function getPluginRoutes(): PluginRoute[] {
 
 export function getPluginSidebarEntries(): PluginSidebarEntry[] {
     return dedupeByPath(pluginSidebarEntries, 'sidebar entry');
+}
+
+// A sibling to dedupeByPath, keyed by `id` instead of `path`: landing page tabs have no path of
+// their own (they're a sub-tab within the /overview route, not a route), so they need their own
+// reserved-id set rather than RESERVED_PATHS/RESERVED_PREFIX.
+function dedupeLandingPageTabs(items: LandingPageTab[]): LandingPageTab[] {
+    const seenIds = new Set<string>();
+    const kept: LandingPageTab[] = [];
+    for (const item of items) {
+        if (RESERVED_LANDING_PAGE_TAB_IDS.has(item.id)) {
+            console.error(`plugin landing page tab id "${item.id}" collides with the built-in Overview tab, dropping it`);
+            continue;
+        }
+        if (seenIds.has(item.id)) {
+            console.error(`plugin landing page tab id "${item.id}" is already claimed by another plugin, dropping it`);
+            continue;
+        }
+        seenIds.add(item.id);
+        kept.push(item);
+    }
+    return kept;
+}
+
+export function getLandingPageTabs(): LandingPageTab[] {
+    return dedupeLandingPageTabs(pluginLandingPageTabs);
 }
 
 export function getEdgeExtraRenderers(): EdgeExtraRenderer[] {

--- a/docs/authentication.md
+++ b/docs/authentication.md
@@ -151,6 +151,18 @@ else:
 - `get`/`list`/`watch`/`create`/`delete` on `traceflows` and
   `traceflows/status`
 - `get` on the `/featuregates` non-resource URL
+- `list` on `namespaces`
+- `list` on `pods` and `services`
+- `list` on `deployments`, `statefulsets` and `daemonsets`
+- `list` on `networkpolicies` (both `networking.k8s.io` and `crd.antrea.io`)
+  and on `clusternetworkpolicies`
+
+The reads from `list` onwards are what the Overview page counts. They are
+read-only and deliberately enumerated rather than granted as a wildcard:
+Kubernetes RBAC has no deny rules, so "everything except Secrets" cannot be
+expressed, and the K8s proxy applies no path allowlist of its own (RBAC is its
+only guard). A wildcard here would therefore let anyone holding the admin
+password read every Secret in the cluster.
 
 Its rule list is static: it only ever changes when you upgrade the chart, and
 you can read exactly what it grants in

--- a/docs/plugins.md
+++ b/docs/plugins.md
@@ -172,7 +172,8 @@ in your plugin's install instructions. See
 
 Everything above adds a whole new page. A plugin can instead extend a page
 Antrea UI already ships — e.g. render extra content in the service map's
-edge details card, or add a column to the flow list table — via
+edge details card, add a column to the flow list table, or add a tab to the
+Overview landing page — via
 `@antrea/ui-plugin-sdk`, modeled on
 [Headlamp's plugin registry](https://headlamp.dev/docs/latest/development/plugins/functionality/)
 (`registerDetailsViewSection`, `registerResourceTableColumnsProcessor`).
@@ -182,7 +183,7 @@ your plugin's entry module — the same place a whole-page plugin calls
 `customElements.define(...)`. A plugin can do both in the same module.
 
 ```ts
-import { registerEdgeExtraRenderer, registerFlowTableColumnsProcessor } from '@antrea/ui-plugin-sdk';
+import { registerEdgeExtraRenderer, registerFlowTableColumnsProcessor, registerLandingPageTab } from '@antrea/ui-plugin-sdk';
 
 // Renders into the service map's edge details card for the currently
 // selected edge. Return null to render nothing for a given selection.
@@ -200,7 +201,18 @@ registerFlowTableColumnsProcessor((columns) => [
     ...columns,
     { key: 'my-column', label: 'My Column', render: (entry) => entry.flow.k8s.flowType },
 ]);
+
+// Adds a tab to the Overview landing page, next to the built-in "Overview"
+// one. `tag`'s custom element is mounted the way the built-in tab is, with the
+// same session-expiry wiring, when the tab is selected.
+registerLandingPageTab({ id: 'my-plugin', label: 'My Plugin', tag: 'antrea-plugin-my-tab' });
 ```
+
+`registerLandingPageTab`'s `id` must be neither `overview` (the built-in tab)
+nor an id another plugin already claimed; the host drops (and logs) whichever
+registration loses the race, as it does for a colliding route. The tab is part
+of the `/overview` route, so it is only reachable by a user the Overview page
+itself is visible to.
 
 All registration functions, including the whole-new-page ones from "Writing
 a plugin" above:
@@ -211,6 +223,7 @@ a plugin" above:
 | `registerSidebarEntry` | Sidebar | Adds a nav entry linking to `entry.path`. |
 | `registerEdgeExtraRenderer` | Service map edge details card | Called with an `EdgeSelection` on each selection change; return `null` to render nothing. |
 | `registerFlowTableColumnsProcessor` | Flow list table | Plugin-added columns aren't sortable — only built-in columns carry the sort key. |
+| `registerLandingPageTab` | Overview landing page | Adds a tab rendering `tab.tag`'s custom element. `tab.id` must not be `overview` or another plugin's id. |
 
 These functions call into a small registry the host sets up on `window`
 before loading any plugin — see


### PR DESCRIPTION
Adds a new default landing page that shows read-only counts of Namespaces, Pods, Services, Deployments, StatefulSets, DaemonSets and NetworkPolicies, optionally scoped to a namespace, with clickable Pod/Service rows that deep-link into the Flow Visibility Service Map pre-filtered to that resource. Access is gated per-resource the same way other pages are, so users without any of these list permissions never see the tab, and RBAC in the antrea-ui-admin-core ClusterRole is extended with the matching read-only list verbs.

Every list request carries a limit, so counting Pods on a large cluster does not pull every Pod spec through the K8s proxy on each load of what is now the landing page. A tile reports the true total by adding the page length to the remainder the API server reports in metadata.remainingItemCount, and falls back to an "N+" floor only when the server truncated the list without reporting that remainder.

Also lets plugins register additional tabs on this landing page via a new registerLandingPageTab SDK call, and lets the Flow Visibility page be seeded with an initial filter so the Overview deep links and any future callers can preset namespace, pod, service and view-mode filters on mount.

<img width="1813" height="1322" alt="image" src="https://github.com/user-attachments/assets/2371e2d4-eccc-450d-9f7b-e0f5be1eacdd" />
