### PR TITLE
Restrict flow visibility to admins

### DIFF
--- a/client/web/antrea-ui-components/src/lib/flow-stream.test.ts
+++ b/client/web/antrea-ui-components/src/lib/flow-stream.test.ts
@@ -67,6 +67,7 @@ describe('FlowStreamClient', () => {
             disconnected: 0,
             authErrors: 0,
             disabled: 0,
+            forbidden: 0,
             onFlows: (flows: unknown[]) => { cb.flows.push(...flows); },
             onError: (err: Error) => { cb.errors.push(err); },
             onDropped: (count: number) => { cb.dropped.push(count); },
@@ -74,6 +75,7 @@ describe('FlowStreamClient', () => {
             onDisconnected: () => { cb.disconnected++; },
             onAuthError: () => { cb.authErrors++; },
             onDisabled: () => { cb.disabled++; },
+            onForbidden: () => { cb.forbidden++; },
         };
         return cb;
     }
@@ -258,6 +260,21 @@ describe('FlowStreamClient', () => {
         await vi.advanceTimersByTimeAsync(0);
 
         expect(cb.disabled).toBe(1);
+        await vi.advanceTimersByTimeAsync(60_000);
+        expect(fetchMock).toHaveBeenCalledTimes(1);
+    });
+
+    // A 403 means this user may not view flow data. Like a 501 it is a permanent answer for the
+    // session, so it must not fall through to !response.ok and drive the backoff loop against it.
+    test('dispatches onForbidden on HTTP 403 and does not reconnect', async () => {
+        stubFetch(async () => sseResponse([], 403));
+        const cb = makeCallbacks();
+        const client = new FlowStreamClient({}, cb, 10);
+        client.start();
+        await vi.advanceTimersByTimeAsync(0);
+
+        expect(cb.forbidden).toBe(1);
+        expect(cb.errors).toHaveLength(0);
         await vi.advanceTimersByTimeAsync(60_000);
         expect(fetchMock).toHaveBeenCalledTimes(1);
     });

--- a/client/web/antrea-ui-components/src/lib/flow-stream.ts
+++ b/client/web/antrea-ui-components/src/lib/flow-stream.ts
@@ -50,6 +50,9 @@ export interface FlowStreamCallbacks {
     /** Called on HTTP 501, i.e. Flow Aggregator integration is disabled for this deployment. This
      * is a static configuration choice, not a transient failure: there is nothing to retry. */
     onDisabled?: () => void;
+    /** Called on HTTP 403, i.e. this user is not permitted to view flow data. Like 501, this is a
+     * permanent answer for the session, not a transient failure: there is nothing to retry. */
+    onForbidden?: () => void;
 }
 
 interface SSEEvent { type: string; data: string; }
@@ -170,6 +173,16 @@ export class FlowStreamClient {
                 this.running = false;
                 this.stopBatchTimer();
                 this.callbacks.onDisabled?.();
+                this.callbacks.onDisconnected?.();
+                return;
+            }
+
+            // Handled here rather than falling through to !response.ok, which would drive the
+            // exponential-backoff reconnect loop against a permanent answer.
+            if (response.status === 403) {
+                this.running = false;
+                this.stopBatchTimer();
+                this.callbacks.onForbidden?.();
                 this.callbacks.onDisconnected?.();
                 return;
             }

--- a/client/web/antrea-ui-components/src/pages/antrea-flow-visibility-page.test.ts
+++ b/client/web/antrea-ui-components/src/pages/antrea-flow-visibility-page.test.ts
@@ -408,6 +408,55 @@ describe('AntreaFlowVisibilityPage — flow visibility disabled server-side', ()
     });
 });
 
+// The 403 twin of the 501 case above, and load-bearing beyond the usual: "a 403 renders a terminal
+// panel naming the actual restriction" is the stated reason useCanViewFlows may fail open on a
+// missing access summary. If a 403 instead left the page retrying, or showed nothing, the frontend
+// gate's fail-open would be stranding users rather than deferring to a better error.
+describe('AntreaFlowVisibilityPage — forbidden by the interim admin-only gate', () => {
+    test('a stream 403 shows the restriction message and does not retry the stream', async () => {
+        const fetchMock = vi.fn(async () => sseResponse([], 403));
+        const page = await mount(fetchMock);
+        await vi.advanceTimersByTimeAsync(0);
+
+        expect(page.shadowRoot!.querySelector('antrea-alert[status="danger"]')?.textContent)
+            .toContain('Flow visibility is restricted to administrators');
+
+        expect(streamCalls(fetchMock)).toHaveLength(1);
+        await vi.advanceTimersByTimeAsync(60_000);
+        expect(streamCalls(fetchMock)).toHaveLength(1);
+    });
+
+    // The 403 is terminal for the page, not just for the one open stream: every user action that
+    // restarts the client goes through _startStream, whose only defence is the
+    // _flowVisibilityDisabled guard. A handler that cleared _client but left that flag unset
+    // would silently reopen the stream on the next interaction and 403 again.
+    //
+    // Driven through the real Pause/Resume buttons rather than a synthetic event: filters and the
+    // pause toggle are plain @click handlers on the toolbar, so there is no event to dispatch, and
+    // a test that invented one would assert nothing. Resume is the cheapest of them — _applyFilter
+    // additionally early-returns on an unchanged filter key, so an "Apply Filters" click with no
+    // pending change would not restart the stream even without the guard.
+    test('the restriction survives a stream restart', async () => {
+        const fetchMock = vi.fn(async () => sseResponse([], 403));
+        const page = await mount(fetchMock);
+        await vi.advanceTimersByTimeAsync(0);
+        expect(streamCalls(fetchMock)).toHaveLength(1);
+
+        const toggle = () => Array.from(page.shadowRoot!.querySelectorAll('antrea-button'))
+            .find(b => b.textContent?.trim() === 'Pause' || b.textContent?.trim() === 'Resume')!;
+        expect(toggle()).toBeDefined();
+        toggle().dispatchEvent(new MouseEvent('click', { bubbles: true, composed: true }));
+        await page.updateComplete;
+        toggle().dispatchEvent(new MouseEvent('click', { bubbles: true, composed: true }));
+        await page.updateComplete;
+        await vi.advanceTimersByTimeAsync(60_000);
+
+        expect(streamCalls(fetchMock)).toHaveLength(1);
+        expect(page.shadowRoot!.querySelector('antrea-alert[status="danger"]')?.textContent)
+            .toContain('Flow visibility is restricted to administrators');
+    });
+});
+
 describe('AntreaFlowVisibilityPage — namespace menu intersects accessible namespaces', () => {
     function jsonResponse(body: unknown, status = 200): Response {
         return new Response(JSON.stringify(body), { status });

--- a/client/web/antrea-ui-components/src/pages/antrea-flow-visibility-page.ts
+++ b/client/web/antrea-ui-components/src/pages/antrea-flow-visibility-page.ts
@@ -75,6 +75,11 @@ export interface FlowTableColumn {
  * columns — modeled on Headlamp's `registerResourceTableColumnsProcessor`. */
 export type FlowTableColumnsProcessor = (columns: FlowTableColumn[]) => FlowTableColumn[];
 
+const FLOW_VISIBILITY_FORBIDDEN_MESSAGE =
+    'Flow visibility is restricted to administrators. Flow data has no per-user authorization ' +
+    'yet, so it is limited to the built-in admin and to Kubernetes cluster admins (see ' +
+    'antrea-ui/docs/authentication.md).';
+
 const FLOW_VISIBILITY_DISABLED_MESSAGE =
     'Flow visibility is disabled on this Antrea UI server. Install or upgrade the chart with ' +
     '--set flowAggregator.enabled=true and a reachable flowAggregator.address (see antrea-ui/hack/deploy-kind.sh).';
@@ -445,6 +450,9 @@ export class AntreaFlowVisibilityPage extends SessionAwarePage {
     @state() private _entries: FlowEntry[] = [];
     @state() private _connected = false;
     @state() private _error: string | null = null;
+    // Set on 501 (integration off) or 403 (this user may not view flow data). Both are terminal
+    // for the session, and both must keep _startStream from re-opening the stream on the next
+    // filter change; the error message says which one it was.
     private _flowVisibilityDisabled = false;
     @state() private _droppedCount = 0;
     @state() private _evictionWarning = false;
@@ -592,6 +600,15 @@ export class AntreaFlowVisibilityPage extends SessionAwarePage {
                 this._client = null;
                 this._connected = false;
                 this._error = FLOW_VISIBILITY_DISABLED_MESSAGE;
+            },
+            onForbidden: () => {
+                // A 403 means this user may not view flow data. Terminal for the session, and
+                // handled the same way as 501: the client has already stopped itself.
+                // Defence in depth — the route guard should keep them off this page entirely.
+                this._flowVisibilityDisabled = true;
+                this._client = null;
+                this._connected = false;
+                this._error = FLOW_VISIBILITY_FORBIDDEN_MESSAGE;
             },
         });
         this._client.start();

--- a/client/web/antrea-ui/src/access.test.tsx
+++ b/client/web/antrea-ui/src/access.test.tsx
@@ -20,7 +20,8 @@ import { Provider } from 'react-redux';
 import { resetAccessSummary } from '@antrea/ui-components';
 import type { AccessSummary } from '@antrea/ui-components';
 import { setupStore, setSession, setAuthenticated } from './store';
-import { AccessProvider, useAccess } from './access';
+import type { RootState } from './store';
+import { AccessProvider, useAccess, useCanViewFlows } from './access';
 import { HomeRedirect } from './pages';
 
 function jsonResponse(body: unknown, status = 200): Response {
@@ -140,10 +141,68 @@ describe('AccessProvider', () => {
     });
 });
 
-describe('HomeRedirect', () => {
-    function renderAt(summary: AccessSummary | null) {
+// useCanViewFlows is the interim admin-only rule for flow data: the built-in admin, or a
+// Kubernetes cluster admin. It mirrors requireFlowVisibility() in pkg/server/api/flowstream.go,
+// which is the authorization decision and fails closed on its own, so like the can() gates this
+// only decides what to render and fails open on a summary that never arrived.
+describe('useCanViewFlows', () => {
+    function FlowProbe() {
+        const { allowed, loaded } = useCanViewFlows();
+        return <div data-testid="probe">{JSON.stringify({ allowed, loaded })}</div>;
+    }
+
+    async function renderProbe(summary: AccessSummary | null, sessionInfo: RootState['sessionInfo']) {
         vi.stubGlobal('fetch', vi.fn().mockResolvedValue(summary ? jsonResponse(summary) : new Response('', { status: 500 })));
-        const store = setupStore({ session: 'authenticated' });
+        const store = setupStore({ session: 'authenticated', sessionInfo });
+        render(
+            <Provider store={store}>
+                <AccessProvider><FlowProbe /></AccessProvider>
+            </Provider>,
+        );
+        await waitFor(() => expect(document.querySelector('[data-testid="probe"]')?.textContent)
+            .toContain('"loaded":true'));
+        return document.querySelector('[data-testid="probe"]')!.textContent!;
+    }
+
+    const adminSession = { authenticated: true, mode: 'admin' as const, username: 'admin' };
+    const tokenSession = { authenticated: true, mode: 'token' as const, username: 'alice' };
+
+    test('the built-in admin is allowed even though clusterAdmin is false', async () => {
+        // Not redundant with the clusterAdmin term: the static-admin session impersonates the
+        // antrea-ui-admin ServiceAccount, whose aggregated ClusterRole holds no */*/* rule, so
+        // the wildcard review genuinely answers false for it.
+        expect(await renderProbe(summaryWith({ clusterAdmin: false }), adminSession)).toContain('"allowed":true');
+    });
+
+    test('a cluster admin is allowed', async () => {
+        expect(await renderProbe(summaryWith({ clusterAdmin: true }), tokenSession)).toContain('"allowed":true');
+    });
+
+    test('an ordinary user is denied', async () => {
+        expect(await renderProbe(summaryWith({ clusterAdmin: false }), tokenSession)).toContain('"allowed":false');
+    });
+
+    test('a null summary (fetch failed) is allowed, deferring to the backend 403', async () => {
+        // Not an authorization hole: requireFlowVisibility still denies, and its 403 names the
+        // actual restriction instead of the generic permission panel. Denying here would instead
+        // strand a cluster admin for the rest of the page lifetime after one transient failure.
+        expect(await renderProbe(null, tokenSession)).toContain('"allowed":true');
+    });
+
+    test('a null sessionInfo is allowed, even against a definite clusterAdmin false', async () => {
+        // The case the backend resolves in the user's favour: sessionInfo is null when the login
+        // page's own GET /auth/session failed, which the built-in admin can hit while still
+        // logging in successfully, and their summary reports clusterAdmin false correctly. So
+        // this is the mode-unknown branch, not the ordinary-user one, and denying it would hide
+        // the page from exactly the caller requireFlowVisibility short-circuits to an allow.
+        expect(await renderProbe(summaryWith({ clusterAdmin: false }), null)).toContain('"allowed":true');
+    });
+});
+
+describe('HomeRedirect', () => {
+    function renderAt(summary: AccessSummary | null, sessionInfo: RootState['sessionInfo'] = null) {
+        vi.stubGlobal('fetch', vi.fn().mockResolvedValue(summary ? jsonResponse(summary) : new Response('', { status: 500 })));
+        const store = setupStore({ session: 'authenticated', sessionInfo });
         return render(
             <Provider store={store}>
                 <AccessProvider>
@@ -153,6 +212,7 @@ describe('HomeRedirect', () => {
                             <Route path="/summary" element={<div data-testid="landed">summary</div>} />
                             <Route path="/traceflow" element={<div data-testid="landed">traceflow</div>} />
                             <Route path="/flows/list" element={<div data-testid="landed">flows</div>} />
+                            <Route path="/settings" element={<div data-testid="landed">settings</div>} />
                         </Routes>
                     </MemoryRouter>
                 </AccessProvider>
@@ -174,9 +234,17 @@ describe('HomeRedirect', () => {
         await waitFor(() => expect(document.querySelector('[data-testid="landed"]')?.textContent).toBe('traceflow'));
     });
 
-    test('falls back to /flows/list when neither is granted', async () => {
-        renderAt(summaryWith());
+    test('lands on /flows/list when only flow visibility is permitted', async () => {
+        renderAt(summaryWith({ clusterAdmin: true }), { authenticated: true, mode: 'token', username: 'alice' });
         await waitFor(() => expect(document.querySelector('[data-testid="landed"]')?.textContent).toBe('flows'));
+    });
+
+    test('falls back to /settings when nothing else is permitted', async () => {
+        // Flow Visibility is no longer the floor: it is gated too, so a user permitted none of
+        // the three lands on Settings, which needs no permission. Needs a definite session: a
+        // null one is mode-unknown, which useCanViewFlows allows.
+        renderAt(summaryWith(), { authenticated: true, mode: 'token', username: 'alice' });
+        await waitFor(() => expect(document.querySelector('[data-testid="landed"]')?.textContent).toBe('settings'));
     });
 
     test('fails open to /summary when the fetch fails', async () => {

--- a/client/web/antrea-ui/src/access.tsx
+++ b/client/web/antrea-ui/src/access.tsx
@@ -67,3 +67,36 @@ export function AccessProvider(props: React.PropsWithChildren) {
 export function useAccess(): AccessContextType {
     return useContext(AccessContext);
 }
+
+// Whether the caller may view flow data: the built-in admin, or a Kubernetes cluster admin.
+//
+// TEMPORARY, mirrors requireFlowVisibility() in pkg/server/api/flowstream.go. That middleware is
+// the authorization decision and it fails closed on its own: every path that is not an allow calls
+// c.Abort(), so the backend never subscribes to the Flow Aggregator for a caller it rejected. This
+// hook only decides whether to render UI that would otherwise just 403, which is why it can fail
+// *open* on a missing answer like the can() gates in access-api.ts do.
+//
+// A definite `clusterAdmin: false` hides the page. A null summary means the access-summary fetch
+// failed (AccessProvider does not retry within a page lifetime), so the backend has not answered at
+// all, and denying here would leave a cluster admin looking at the generic permission panel for the
+// rest of the page lifetime with nothing pointing at "permissions failed to load". Allowing instead
+// defers to requireFlowVisibility, whose 403 onForbidden renders as a terminal panel naming the
+// actual restriction — a better answer either way.
+//
+// A null sessionInfo allows for the same reason, and with more force. It means the login page's
+// own GET /auth/session failed, which _submit swallows (the login itself succeeded, there is just
+// nothing to display for it), so a built-in admin can reach an authenticated app with mode
+// unknown. Their summary then reports clusterAdmin false — correctly, the antrea-ui-admin
+// ServiceAccount holds no */*/* rule — and denying on it would hide the page from precisely the
+// caller requireFlowVisibility short-circuits to an allow. Unlike a null summary, this is not even
+// an unknown answer on the backend's side: it is one the backend resolves in the user's favour.
+// The cost is the same as above, plus the initial redirect: HomeRedirect reads this hook too, so
+// such a caller lands on the flows page and meets the 403 panel there instead of Settings. Both
+// only during a failure that also broke their session probe.
+//
+// eslint-disable-next-line react-refresh/only-export-components
+export function useCanViewFlows(): { allowed: boolean, loaded: boolean } {
+    const { summary, loaded } = useAccess();
+    const info = useSelector((state: RootState) => state.sessionInfo);
+    return { allowed: info === null || info.mode === 'admin' || summary === null || summary.clusterAdmin === true, loaded };
+}

--- a/client/web/antrea-ui/src/nav.test.tsx
+++ b/client/web/antrea-ui/src/nav.test.tsx
@@ -19,10 +19,18 @@ import { MemoryRouter } from 'react-router';
 import NavTab from './nav';
 import type { PluginSidebarEntry } from './plugins';
 import type { AccessSummary } from '@antrea/ui-components';
-import { useAccess } from './access';
+import { useAccess, useCanViewFlows } from './access';
 
-vi.mock('./access', () => ({ useAccess: vi.fn() }));
+// Exhaustive factory, so every hook nav.tsx imports from './access' has to be listed here.
+vi.mock('./access', () => ({ useAccess: vi.fn(), useCanViewFlows: vi.fn() }));
 const mockUseAccess = vi.mocked(useAccess);
+const mockUseCanViewFlows = vi.mocked(useCanViewFlows);
+
+// Flow Visibility is gated on its own rule now (see useCanViewFlows), so every test that expects
+// the group to render has to grant it.
+function allowFlows(allowed: boolean, loaded = true) {
+    mockUseCanViewFlows.mockReturnValue({ allowed, loaded });
+}
 
 const podCounterEntry: PluginSidebarEntry = { label: 'Pod Counter', path: '/plugin/pod-counter' };
 
@@ -39,6 +47,7 @@ function summaryAllowing(rules: Partial<AccessSummary['rules']> = {}): AccessSum
 describe('NavTab', () => {
     beforeEach(() => {
         mockUseAccess.mockReturnValue({ summary: null, loaded: true });
+        allowFlows(true);
     });
 
     test('no plugin sidebar entries renders no extra items', () => {
@@ -86,9 +95,10 @@ describe('NavTab', () => {
 describe('NavTab — Flow Visibility built-in nesting', () => {
     beforeEach(() => {
         mockUseAccess.mockReturnValue({ summary: null, loaded: true });
+        allowFlows(true);
     });
 
-    test('Flow List and Service Map render nested under Flow Visibility, unconditionally', () => {
+    test('Flow List and Service Map render nested under Flow Visibility when the gate allows it', () => {
         render(<NavTab pluginSidebarEntries={[]} />, { wrapper: MemoryRouter });
 
         // Both the Flow Visibility header itself and the nested Flow List item link to
@@ -123,6 +133,7 @@ describe('NavTab — Flow Visibility built-in nesting', () => {
 describe('NavTab — nested plugin entries', () => {
     beforeEach(() => {
         mockUseAccess.mockReturnValue({ summary: null, loaded: true });
+        allowFlows(true);
     });
 
     test('a plugin entry nested under another plugin entry renders inside an antrea-nav-group', () => {
@@ -196,6 +207,7 @@ describe('NavTab — nested plugin entries', () => {
     // while unloaded keeps that reasoning consistent for its nested children.
     test('an entry nested under a built-in page renders nothing while access is still loading', () => {
         mockUseAccess.mockReturnValue({ summary: null, loaded: false });
+        allowFlows(false, false);
         const childEntry: PluginSidebarEntry = { label: 'Extra Traceflow Page', path: '/plugin/extra-traceflow', parentPath: 'traceflow' };
         render(<NavTab pluginSidebarEntries={[childEntry]} />, { wrapper: MemoryRouter });
 
@@ -224,19 +236,25 @@ describe('NavTab — nested plugin entries', () => {
 });
 
 describe('NavTab — permission gating', () => {
+    beforeEach(() => {
+        allowFlows(true);
+    });
+
     test('while unloaded, renders no core items', () => {
         mockUseAccess.mockReturnValue({ summary: null, loaded: false });
+        allowFlows(false, false);
         render(<NavTab pluginSidebarEntries={[]} />, { wrapper: MemoryRouter });
 
         expect(document.querySelector('a[href="/summary"]')).toBeNull();
         expect(document.querySelector('a[href="/traceflow"]')).toBeNull();
-        // Flow Visibility and Settings have no per-user RBAC, so they are not gated on load.
-        expect(document.querySelector('a[href="/flows/list"]')).not.toBeNull();
+        expect(document.querySelector('a[href="/flows/list"]')).toBeNull();
+        // Settings needs no permission, so it is not gated on load.
         expect(document.querySelector('a[href="/settings"]')).not.toBeNull();
     });
 
     test('a null summary (fetch failed) fails open: both core tabs show', () => {
         mockUseAccess.mockReturnValue({ summary: null, loaded: true });
+        allowFlows(true);
         render(<NavTab pluginSidebarEntries={[]} />, { wrapper: MemoryRouter });
 
         expect(document.querySelector('a[href="/summary"]')).not.toBeNull();
@@ -261,5 +279,30 @@ describe('NavTab — permission gating', () => {
         render(<NavTab pluginSidebarEntries={[]} />, { wrapper: MemoryRouter });
 
         expect(document.querySelector('a[href="/summary"]')).toBeNull();
+    });
+
+    // The interim admin-only restriction on flow data (see useCanViewFlows). Unlike the gates
+    // above, this one is not a per-user RBAC answer, but it hides the entry the same way.
+    test('Flow Visibility is hidden, with its sub-pages, when the gate denies it', () => {
+        mockUseAccess.mockReturnValue({ summary: summaryAllowing(), loaded: true });
+        allowFlows(false);
+        render(<NavTab pluginSidebarEntries={[]} />, { wrapper: MemoryRouter });
+
+        expect(document.querySelector('a[href="/flows/list"]')).toBeNull();
+        expect(document.querySelector('a[href="/flows/map"]')).toBeNull();
+    });
+
+    // Same promotion as the gated-off Traceflow case above: plugins.ts accepts 'flows' as a parent
+    // unconditionally, so a child registered under it must not disappear with the parent.
+    test('a plugin entry nested under a denied Flow Visibility renders at top level', () => {
+        mockUseAccess.mockReturnValue({ summary: summaryAllowing(), loaded: true });
+        allowFlows(false);
+        const childEntry: PluginSidebarEntry = { label: 'Extra Flows Page', path: '/plugin/extra-flows', parentPath: 'flows' };
+        render(<NavTab pluginSidebarEntries={[childEntry]} />, { wrapper: MemoryRouter });
+
+        expect(document.querySelector('a[href="/flows/list"]')).toBeNull();
+        const childLink = document.querySelector('a[href="/plugin/extra-flows"]');
+        expect(childLink).not.toBeNull();
+        expect(childLink!.closest('antrea-nav-group')).toBeNull();
     });
 });

--- a/client/web/antrea-ui/src/nav.tsx
+++ b/client/web/antrea-ui/src/nav.tsx
@@ -20,7 +20,7 @@ import { Link } from 'react-router';
 import '@antrea/ui-components';
 import { can, canViewSummary, GATE_TRACEFLOW_CREATE } from '@antrea/ui-components';
 import type { PluginSidebarEntry } from './plugins';
-import { useAccess } from './access';
+import { useAccess, useCanViewFlows } from './access';
 
 function DashboardIcon() {
     return (
@@ -112,6 +112,10 @@ export default function NavTab({ pluginSidebarEntries }: { pluginSidebarEntries:
     // loaded reads better than entries vanishing if the answer turns out to restrict something.
     const showSummary = loaded && canViewSummary(summary);
     const showTraceflow = loaded && can(summary, GATE_TRACEFLOW_CREATE);
+    // Flow Visibility is gated on a rule of its own (useCanViewFlows), not on the access summary
+    // alone, but it hides on the same "wait for loaded" terms as the two above.
+    const { allowed: canViewFlows, loaded: flowsLoaded } = useCanViewFlows();
+    const showFlows = flowsLoaded && canViewFlows;
 
     // Plugin entries with a parentPath (already resolved/normalized by plugins.ts's
     // resolveParentPaths — always a leading-slash-stripped path, whether that path belongs to a
@@ -132,15 +136,18 @@ export default function NavTab({ pluginSidebarEntries }: { pluginSidebarEntries:
     // the same nested-nav treatment for free. Returns `item` unchanged when nothing nests under it.
     //
     // `show` is false when `path`'s own page isn't rendered at all — gated off by RBAC (Summary,
-    // Traceflow), or the access summary hasn't loaded yet. plugins.ts's resolveParentPaths accepts
-    // a gated built-in page as a valid parent unconditionally (it has no way to know it's gated
-    // for a given user), so a nested child would otherwise have no render site.
+    // Traceflow) or by the interim admin-only rule (Flow Visibility), or the access summary hasn't
+    // loaded yet. plugins.ts's resolveParentPaths accepts a gated built-in page as a valid parent
+    // unconditionally (it has no way to know it's gated for a given user), so a nested *plugin*
+    // child would otherwise have no render site.
     //
     // Those two `!show` causes are deliberately not treated alike (closing over `loaded` directly,
-    // rather than taking it as a parameter — every caller either passes `show: true`, for which it
-    // is never consulted, or is Summary/Traceflow, for which it is `loaded` itself): "the parent is
-    // definitely gated off for this user" (`loaded`) promotes its children to top level, so they
-    // don't silently disappear, while "we don't know yet" (`!loaded`) hides them too, consistent
+    // rather than taking it as a parameter — every gated caller's own `show` is conjoined with this
+    // same `loaded`, Flow Visibility's by way of useCanViewFlows re-exporting it unchanged, so if
+    // that hook ever gates its `loaded` on more, this closure has to take it as a parameter):
+    // "the parent is definitely gated off for this user"
+    // (`loaded`) promotes its plugin children to top level, so they don't silently disappear,
+    // while "we don't know yet" (`!loaded`) hides them too, consistent
     // with the `showSummary`/`showTraceflow` comment above ("entries popping in once loaded reads
     // better than entries vanishing") — a promoted child would otherwise pop in immediately and
     // then jump into the group once loaded resolves, a reflow that comment argues against for the
@@ -156,7 +163,10 @@ export default function NavTab({ pluginSidebarEntries }: { pluginSidebarEntries:
 
         if (!show) {
             if (!loaded) return null;
-            return [...builtinChildren.map((child) => child.node), ...renderedPluginChildren];
+            // Only the plugin children are promoted. `builtinChildren` are sub-pages of `path`'s
+            // own page (Flow List / Service Map), gated off by the very same decision, so keeping
+            // them would render links to pages this user cannot open.
+            return renderedPluginChildren;
         }
         if (builtinChildren.length === 0 && pluginChildren.length === 0) return item;
         const hasActiveChild =
@@ -189,7 +199,7 @@ export default function NavTab({ pluginSidebarEntries }: { pluginSidebarEntries:
                     </Link>
                 </antrea-nav-item>
             ))}
-            {withNestedChildren('flows', true, (
+            {withNestedChildren('flows', showFlows, (
                 <antrea-nav-item {...(pathStartsWith(pathname, '/flows') ? { active: true } : {})}>
                     <Link to="/flows/list">
                         <EyeIcon />

--- a/client/web/antrea-ui/src/pages.test.tsx
+++ b/client/web/antrea-ui/src/pages.test.tsx
@@ -17,8 +17,11 @@
 import { act, render, waitFor } from '@testing-library/react';
 import { Provider } from 'react-redux';
 import { setupStore } from './store';
-import { SummaryPage } from './pages';
+import { FlowVisibilityPage, SummaryPage } from './pages';
 import { AccessProvider } from './access';
+import { resetAccessSummary } from '@antrea/ui-components';
+import type { AccessSummary } from '@antrea/ui-components';
+import type { RootState } from './store';
 
 // AntreaSummaryPage is a Lit web component with its own shadow DOM; we only need
 // its host element here to dispatch the antrea-session-expired event.
@@ -43,6 +46,9 @@ function stubLocationHref() {
 
 afterEach(() => {
     vi.unstubAllGlobals();
+    // Successful summaries are cached for the session, so one test's would otherwise answer the
+    // next one's fetch.
+    resetAccessSummary();
 });
 
 describe('useLitPage — antrea-session-expired', () => {
@@ -79,5 +85,52 @@ describe('useLitPage — antrea-session-expired', () => {
         } finally {
             location.restore();
         }
+    });
+});
+
+// The route guard, as opposed to the nav entry. nav.test.tsx covers the entry, but it mocks
+// useCanViewFlows wholesale, so nothing there connects the two — and the entry is not the
+// enforcement point anyway: a user who bookmarked /flows/list or typed it never goes near the nav.
+// These use the real hook through AccessProvider, so they also pin that the page and the nav read
+// the same rule rather than two that happen to agree today.
+describe('FlowVisibilityPage — route guard', () => {
+    function summaryWith(overrides: Partial<AccessSummary> = {}): AccessSummary {
+        return {
+            username: 'alice',
+            groups: [],
+            clusterAdmin: false,
+            rules: { resourceRules: [], nonResourceRules: [], incomplete: false },
+            namespaces: [],
+            ...overrides,
+        };
+    }
+
+    function renderPage(summary: AccessSummary, sessionInfo: RootState['sessionInfo']) {
+        vi.stubGlobal('fetch', vi.fn().mockResolvedValue(
+            new Response(JSON.stringify(summary), { status: 200 })));
+        const store = setupStore({ session: 'authenticated', sessionInfo });
+        return render(
+            <Provider store={store}>
+                <AccessProvider><FlowVisibilityPage view="list" /></AccessProvider>
+            </Provider>,
+        );
+    }
+
+    const tokenSession = { authenticated: true, mode: 'token' as const, username: 'alice' };
+
+    test('renders the permission panel, and never the page, for a denied user', async () => {
+        renderPage(summaryWith({ clusterAdmin: false }), tokenSession);
+        await waitFor(() => expect(document.querySelector('antrea-alert')).not.toBeNull());
+        expect(document.querySelector('antrea-alert')!.textContent)
+            .toContain('You do not have permission to view this page');
+        // The point of the guard: the Lit element is never constructed, so it never opens the
+        // stream. Asserting the panel alone would pass with both rendered.
+        expect(document.querySelector('antrea-flow-visibility-page')).toBeNull();
+    });
+
+    test('renders the page for a cluster admin', async () => {
+        renderPage(summaryWith({ clusterAdmin: true }), tokenSession);
+        await waitFor(() => expect(document.querySelector('antrea-flow-visibility-page')).not.toBeNull());
+        expect(document.querySelector('antrea-alert')).toBeNull();
     });
 });

--- a/client/web/antrea-ui/src/pages.tsx
+++ b/client/web/antrea-ui/src/pages.tsx
@@ -17,7 +17,6 @@
 import React, { useRef, useCallback } from 'react';
 import '@antrea/ui-components';
 import { can, canViewSummary, GATE_TRACEFLOW_CREATE } from '@antrea/ui-components';
-import type { AccessSummary } from '@antrea/ui-components';
 import { Navigate } from 'react-router';
 import { useLogout } from './logout';
 import { getEdgeExtraRenderers, getFlowTableColumnsProcessors } from './plugins';
@@ -37,14 +36,15 @@ export function HomeRedirect() {
     return <Navigate to="/flows/list" replace />;
 }
 
-// Wraps a page element so it only renders when predicate(summary) is true, matching the
-// predicate the nav uses to decide whether to show the tab in the first place — one predicate per
-// page, so the nav entry and the route guard cannot drift apart. While the access summary hasn't
-// loaded yet, renders nothing rather than either the page or the permission panel.
-function RequirePermission({ predicate, children }: { predicate: (s: AccessSummary | null) => boolean, children: React.ReactNode }) {
-    const { summary, loaded } = useAccess();
+// Wraps a page element so it only renders when `allowed` is true, matching the rule the nav uses
+// to decide whether to show the tab in the first place — one rule per page, so the nav entry and
+// the route guard cannot drift apart. The rule is evaluated by the caller rather than passed in as
+// a predicate over the access summary, so that a gate needing more than the summary to answer can
+// reuse the same wrapper. While the answer hasn't loaded yet, renders nothing rather than either
+// the page or the permission panel.
+function RequirePermission({ allowed, loaded, children }: { allowed: boolean, loaded: boolean, children: React.ReactNode }) {
     if (!loaded) return null;
-    if (!predicate(summary)) {
+    if (!allowed) {
         return (
             <antrea-alert status="warning">
                 You do not have permission to view this page.
@@ -86,8 +86,9 @@ function useLitPage() {
 
 export function SummaryPage() {
     const { ref } = useLitPage();
+    const { summary, loaded } = useAccess();
     return (
-        <RequirePermission predicate={canViewSummary}>
+        <RequirePermission allowed={canViewSummary(summary)} loaded={loaded}>
             <antrea-summary-page ref={ref} />
         </RequirePermission>
     );
@@ -95,8 +96,9 @@ export function SummaryPage() {
 
 export function TraceflowPage() {
     const { ref } = useLitPage();
+    const { summary, loaded } = useAccess();
     return (
-        <RequirePermission predicate={(s) => can(s, GATE_TRACEFLOW_CREATE)}>
+        <RequirePermission allowed={can(summary, GATE_TRACEFLOW_CREATE)} loaded={loaded}>
             <antrea-traceflow-page ref={ref} />
         </RequirePermission>
     );

--- a/client/web/antrea-ui/src/pages.tsx
+++ b/client/web/antrea-ui/src/pages.tsx
@@ -20,28 +20,34 @@ import { can, canViewSummary, GATE_TRACEFLOW_CREATE } from '@antrea/ui-component
 import { Navigate } from 'react-router';
 import { useLogout } from './logout';
 import { getEdgeExtraRenderers, getFlowTableColumnsProcessors } from './plugins';
-import { useAccess } from './access';
+import { useAccess, useCanViewFlows } from './access';
 
 // Picks the first route the user is actually permitted to see, so a partially-authorized user
 // doesn't land on a Summary page that's just going to show the permission panel. While the
 // access summary hasn't loaded yet, renders nothing.
 export function HomeRedirect() {
     const { summary, loaded } = useAccess();
+    // useCanViewFlows' own `loaded` is dropped because it is this same one today. If that hook
+    // ever gates loading on something else (a second fetch, say), take it and conjoin it with the
+    // check below, or this redirects on a half-loaded answer. Same coupling nav.tsx notes.
+    const { allowed: canViewFlows } = useCanViewFlows();
     if (!loaded) return null;
     if (canViewSummary(summary)) return <Navigate to="/summary" replace />;
     if (can(summary, GATE_TRACEFLOW_CREATE)) return <Navigate to="/traceflow" replace />;
-    // Flow Visibility has no per-user RBAC today (see docs/authentication.md), so it is always
-    // eligible and is the practical floor here. Goes straight to its default sub-page (Flow
-    // List) rather than "/flows", which only exists to redirect there itself.
-    return <Navigate to="/flows/list" replace />;
+    // Flow Visibility goes straight to its default sub-page (Flow List) rather than "/flows",
+    // which only exists to redirect there itself. It is no longer the floor: it is restricted to
+    // admins for now (see useCanViewFlows), so a user permitted none of the three lands on
+    // Settings, which the nav always shows and which needs no permission.
+    if (canViewFlows) return <Navigate to="/flows/list" replace />;
+    return <Navigate to="/settings" replace />;
 }
 
 // Wraps a page element so it only renders when `allowed` is true, matching the rule the nav uses
 // to decide whether to show the tab in the first place — one rule per page, so the nav entry and
 // the route guard cannot drift apart. The rule is evaluated by the caller rather than passed in as
-// a predicate over the access summary, so that a gate needing more than the summary to answer can
-// reuse the same wrapper. While the answer hasn't loaded yet, renders nothing rather than either
-// the page or the permission panel.
+// a predicate over the access summary, so that a gate needing more than the summary (Flow
+// Visibility also needs the session mode) can reuse the same wrapper. While the answer hasn't
+// loaded yet, renders nothing rather than either the page or the permission panel.
 function RequirePermission({ allowed, loaded, children }: { allowed: boolean, loaded: boolean, children: React.ReactNode }) {
     if (!loaded) return null;
     if (!allowed) {
@@ -110,13 +116,16 @@ export function TraceflowPage() {
 // sidebar (nav.tsx) concern.
 export function FlowVisibilityPage({ view }: { view: 'list' | 'map' }) {
     const { ref } = useLitPage();
+    const { allowed, loaded } = useCanViewFlows();
     return (
-        <antrea-flow-visibility-page
-            ref={ref}
-            viewMode={view}
-            edgeExtraRenderers={getEdgeExtraRenderers()}
-            flowTableColumnsProcessors={getFlowTableColumnsProcessors()}
-        />
+        <RequirePermission allowed={allowed} loaded={loaded}>
+            <antrea-flow-visibility-page
+                ref={ref}
+                viewMode={view}
+                edgeExtraRenderers={getEdgeExtraRenderers()}
+                flowTableColumnsProcessors={getFlowTableColumnsProcessors()}
+            />
+        </RequirePermission>
     );
 }
 

--- a/docs/authentication.md
+++ b/docs/authentication.md
@@ -175,16 +175,57 @@ installed next month adds".
 
 The flow visibility stream (`GET /api/v1/flows/stream`) is the one part of the
 UI that per-user RBAC does **not** cover. The backend subscribes to the Flow
-Aggregator over its own mTLS gRPC connection, and nothing consults the caller's
-Kubernetes permissions, so any user who can log in can see every flow the Flow
-Aggregator exports — including a user whose RBAC grants them nothing else, who
-will get 403s on every other page.
+Aggregator over its own mTLS gRPC connection, and no per-user answer exists to
+filter what comes back, so every caller who reaches the endpoint sees every flow
+the Flow Aggregator exports. The interim restriction below narrows *who reaches
+it*, using a coarse cluster-admin check; it does not make the data per-user.
 
-Authorization for this endpoint is being implemented upstream in
-[antrea-io/antrea#8221](https://github.com/antrea-io/antrea/pull/8221). Until
-that lands, treat "can log in at all" as the access-control boundary for flow
-data: if that is too broad for your deployment, disable the integration with
-`flowAggregator.enabled=false`, or restrict which modes can be used to log in.
+**Interim restriction.** Because there is no per-user answer to fall back on,
+the endpoint is currently limited to two kinds of caller:
+
+- whoever logged in with the built-in admin password, and
+- a Kubernetes cluster admin, meaning an identity holding a cluster-wide
+  wildcard grant (`verb: *`, `apiGroup: *`, `resource: *`).
+
+Everyone else gets a 403. A review the API server could not answer is not an
+allow either: a rejected credential becomes a 401 that also ends the session,
+and anything else becomes a 5xx, or the API server's own status if it refused
+the review itself. Of those, only a 403 and the 401 are terminal on the page;
+the rest are retried a bounded number of times before it gives up. Note that a
+review the API server *forbade* therefore arrives as a 403 and is
+indistinguishable on the page from an ordinary denial — it renders the same
+"restricted to administrators" panel, which in that case names the wrong
+reason. That needs a cluster where the caller cannot create
+SelfSubjectAccessReviews at all, which the default `system:basic-user` binding
+grants everyone.
+
+The Flow Visibility entry does not appear in the UI's navigation for a denied
+caller, with one deliberate exception described under [What the frontend knows
+about your permissions](#what-the-frontend-knows-about-your-permissions): when
+the frontend has no permission answer at all, it shows the entry and lets the
+403 explain, rather than hiding the page on a failure the backend never saw.
+
+This narrows who is exposed; it does not make flow data per-user. Within that
+set, every caller still sees every flow.
+
+The check runs when the stream is opened, not continuously. A caller whose
+cluster-admin binding is removed keeps the stream they already have until it
+reconnects — on a filter change, an unpause, a network blip, or the session's
+absolute lifetime cap (12h by default), whichever comes first.
+
+This is temporary. Authorization for `FlowStreamService` is being implemented
+upstream in
+[antrea-io/antrea#8221](https://github.com/antrea-io/antrea/pull/8221); once it
+lands and Antrea UI can present the caller's identity to the Flow Aggregator,
+the restriction goes away and flow data becomes per-user like everything else.
+
+To turn the integration off entirely rather than restrict it, deploy with
+`flowAggregator.enabled=false` (the chart default). The endpoint then returns
+501 for every user, including admins.
+
+Note that this restriction is Antrea UI's alone. Enabling `FlowStreamService`
+in the Flow Aggregator means anyone with network access to it can read flow
+data directly, regardless of what Antrea UI allows.
 
 ### The plugin trade-off
 
@@ -239,6 +280,16 @@ The response looks like:
 request the UI makes is still authorized by the API server exactly as before;
 a wrong answer here costs a spurious 403 (or a spuriously hidden button) and
 nothing more.
+
+`clusterAdmin` currently drives one such hint that hides a whole page rather
+than a button: Flow Visibility does not render for a caller who is neither the
+built-in admin (per the session, not this endpoint) nor a cluster admin (per
+this field), mirroring the interim restriction described in [Flow data is not
+yet per-user](#flow-data-is-not-yet-per-user). The authorization decision is
+still the backend's — it rejects the stream itself — and the hint follows the
+rule above, showing the page whenever the frontend lacks a definite answer:
+no summary arrived, or the session probe that says whether this is the built-in
+admin did not. That mirroring goes away with the restriction.
 
 There is no partial answer. A `200` means every field is authoritative;
 anything else means the frontend shows everything, exactly as it did before

--- a/docs/plugins.md
+++ b/docs/plugins.md
@@ -211,12 +211,14 @@ instead of a flat item. Nesting is one level deep: pointing `parentPath` at
 an entry that is itself nested is invalid, and the host drops the nesting
 (falling back to a top-level entry) and logs why.
 
-`summary` and `traceflow` are themselves gated by per-user RBAC (see
-[authentication.md](authentication.md)) and simply don't render for a user
-who fails that gate. Nesting under either still falls back to a top-level
-entry for such a user, same as the invalid-nesting case above — but silently,
-per user, and without dropping anything: the entry itself is always valid,
-it just isn't always nested.
+`flows`, `summary` and `traceflow` are themselves gated and simply don't
+render for a user who fails the gate — `summary` and `traceflow` by per-user
+RBAC, and `flows` by an interim restriction to administrators that goes away
+once flow data is authorized per user (see
+[authentication.md](authentication.md) for both). Nesting under any of them
+still falls back to a top-level entry for such a user, same as the
+invalid-nesting case above — but silently, per user, and without dropping
+anything: the entry itself is always valid, it just isn't always nested.
 
 `@antrea/ui-plugin-sdk` is a devDependency resolved from this repo's
 workspace (`file:../../../client/web/antrea-ui-plugin-sdk` in

--- a/pkg/auth/session/context.go
+++ b/pkg/auth/session/context.go
@@ -60,8 +60,8 @@ func NewSessionAuth(store Store, s *Session) *RequestAuth {
 //
 // username is the identity the API server resolved the token to. Callers must have validated the
 // token before calling this: unlike a session, whose credential was checked when the session was
-// created, nothing downstream re-checks an ephemeral one, and two routes never present it to
-// Kubernetes at all.
+// created, nothing downstream re-checks an ephemeral one, and two route handlers never present it
+// to Kubernetes at all.
 //
 // Mode is always ModeToken, whatever the token actually is - it says how the caller
 // authenticated to antrea-ui, not what kind of token they hold. Do not use it to grant anything:

--- a/pkg/handlers/flowstream/handler.go
+++ b/pkg/handlers/flowstream/handler.go
@@ -62,9 +62,12 @@ var errUnauthenticatedStream = errors.New("flow stream request carries no resolv
 //
 // Known gap, deliberate for now: this endpoint is authenticated but not authorized per user. The
 // subscriber reaches the Flow Aggregator over antrea-ui's own mTLS gRPC connection, so unlike
-// every other API route, the caller's Kubernetes RBAC has no say in what they see — any user who
-// can log in sees every exported flow. Authorization is being implemented upstream in
-// antrea-io/antrea#8221; see the "Flow data is not yet per-user" section of docs/authentication.md.
+// every other API route, the caller's Kubernetes RBAC has no say in what they see. As an interim
+// measure the route is restricted to the built-in admin and to Kubernetes cluster admins
+// (requireFlowVisibility in pkg/server/api/flowstream.go), which narrows who is exposed but does
+// not close the gap: within that set, every caller still sees every exported flow. Authorization
+// is being implemented upstream in antrea-io/antrea#8221; see the "Flow data is not yet per-user"
+// section of docs/authentication.md.
 type SSEHandler struct {
 	logger  logr.Logger
 	handler FlowStreamSubscriber

--- a/pkg/server/api/access.go
+++ b/pkg/server/api/access.go
@@ -15,6 +15,7 @@
 package api
 
 import (
+	"context"
 	"fmt"
 	"net/http"
 	"strings"
@@ -24,6 +25,7 @@ import (
 	authorizationv1 "k8s.io/api/authorization/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/util/validation"
+	"k8s.io/client-go/kubernetes"
 
 	apisv1 "antrea.io/antrea-ui/apis/v1"
 	"antrea.io/antrea-ui/pkg/auth/session"
@@ -31,6 +33,25 @@ import (
 	"antrea.io/antrea-ui/pkg/server/authn"
 	"antrea.io/antrea-ui/pkg/server/errors"
 )
+
+// selfSubjectClusterAdmin reports whether the caller holds a cluster-wide wildcard grant. A
+// literal "*" in the request matches only rules that themselves hold "*", which is exactly the
+// wildcard-ClusterRole case.
+func selfSubjectClusterAdmin(ctx context.Context, clientset kubernetes.Interface) (bool, error) {
+	review, err := clientset.AuthorizationV1().SelfSubjectAccessReviews().Create(ctx, &authorizationv1.SelfSubjectAccessReview{
+		Spec: authorizationv1.SelfSubjectAccessReviewSpec{
+			ResourceAttributes: &authorizationv1.ResourceAttributes{
+				Verb:     "*",
+				Group:    "*",
+				Resource: "*",
+			},
+		},
+	}, metav1.CreateOptions{})
+	if err != nil {
+		return false, err
+	}
+	return review.Status.Allowed, nil
+}
 
 // GetAccessSummary handles GET /api/v1/access-summary. AccessSummary is a rendering hint, never an
 // authorization decision, so the contract is simply: 200 means every field is a real answer,
@@ -93,21 +114,12 @@ func (s *Server) GetAccessSummary(c *gin.Context) {
 			result.Rules.Incomplete = true
 		}
 
-		// Step 3: cluster-admin. A literal "*" in the request matches only rules that
-		// themselves hold "*", which is exactly the wildcard-ClusterRole case.
-		review, err := clientset.AuthorizationV1().SelfSubjectAccessReviews().Create(ctx, &authorizationv1.SelfSubjectAccessReview{
-			Spec: authorizationv1.SelfSubjectAccessReviewSpec{
-				ResourceAttributes: &authorizationv1.ResourceAttributes{
-					Verb:     "*",
-					Group:    "*",
-					Resource: "*",
-				},
-			},
-		}, metav1.CreateOptions{})
+		// Step 3: cluster-admin.
+		clusterAdmin, err := selfSubjectClusterAdmin(ctx, clientset)
 		if err != nil {
 			return s.k8sError(c, err, "error when evaluating access summary")
 		}
-		result.ClusterAdmin = review.Status.Allowed
+		result.ClusterAdmin = clusterAdmin
 
 		// Step 4: namespaces. Static admin is answered without consulting the resolver at all,
 		// so that a resolver failure cannot fail the one session an operator uses to fix a

--- a/pkg/server/api/flowstream.go
+++ b/pkg/server/api/flowstream.go
@@ -1,0 +1,96 @@
+// Copyright 2026 Antrea Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package api
+
+import (
+	"fmt"
+	"net/http"
+
+	"github.com/gin-gonic/gin"
+
+	"antrea.io/antrea-ui/pkg/auth/session"
+	"antrea.io/antrea-ui/pkg/server/authn"
+	"antrea.io/antrea-ui/pkg/server/errors"
+)
+
+// requireFlowVisibility restricts the flow stream to the built-in admin and to Kubernetes cluster
+// admins. TEMPORARY: flow data has no per-user authorization, so "can log in at all" is too broad a
+// boundary for it (antrea-io/antrea-ui#1387). Remove once FlowStreamService authorizes per user.
+//
+// One extra SelfSubjectAccessReview per stream *open*, not per flow. Opens are not once per page
+// load: the page reopens the stream on every filter change and unpause, and every reconnect
+// attempt passes through here again.
+func (s *Server) requireFlowVisibility() gin.HandlerFunc {
+	return func(c *gin.Context) {
+		// The static-admin session impersonates the antrea-ui-admin ServiceAccount, whose
+		// aggregated ClusterRole holds no */*/* rule, so the wildcard review below answers
+		// false for it. Short-circuiting before any Kubernetes call is also what keeps a
+		// broken API server from locking out the one session an operator uses to fix a
+		// cluster — the same reasoning as step 4 of GetAccessSummary.
+		if ra, ok := authn.RequestAuthFromGin(c); ok && ra.Mode == session.ModeAdmin {
+			c.Next()
+			return
+		}
+
+		sErr := func() *errors.ServerError {
+			ctx := c.Request.Context()
+			clientset, err := s.clientFactory.KubernetesClientForRequest(ctx)
+			if err != nil {
+				return &errors.ServerError{
+					Code: http.StatusInternalServerError,
+					Err:  fmt.Errorf("failed to build K8s client for request: %w", err),
+				}
+			}
+			// Fails closed: a review we could not evaluate is not an allow. A transport
+			// failure lands in k8sError's default branch as a 500, and an
+			// IsUnauthorized error invalidates the session and clears the cookie, which
+			// is the right outcome for a credential the API server rejected.
+			clusterAdmin, err := selfSubjectClusterAdmin(ctx, clientset)
+			if err != nil {
+				return s.k8sError(c, err, "error when evaluating flow visibility access")
+			}
+			if clusterAdmin {
+				return nil
+			}
+			// Logged explicitly, because nothing else would: LogError below is a
+			// no-op for a ServerError carrying no Err, which a deliberate denial
+			// does not. Authorization here is antrea-ui's own decision rather
+			// than the API server's (UpdatePassword is the only other such
+			// denial), so while the API server does audit the caller's own
+			// SelfSubjectAccessReview, nothing anywhere records that a flow
+			// stream was refused. This line is that record.
+			username := ""
+			if ra, ok := authn.RequestAuthFromGin(c); ok {
+				username = ra.Username
+			}
+			s.logger.Info("Denied flow visibility request", "username", username)
+			// Names the restriction, so the message is distinguishable from the
+			// Kubernetes RBAC text an SSAR 403 would carry.
+			return &errors.ServerError{
+				Code:    http.StatusForbidden,
+				Message: "Flow visibility is restricted to administrators",
+			}
+		}()
+		if sErr != nil {
+			errors.HandleError(c, sErr)
+			s.LogError(sErr, "Failed to authorize flow visibility request")
+			// HandleError writes a response but does not abort, so without this the
+			// handler would still run and start streaming.
+			c.Abort()
+			return
+		}
+		c.Next()
+	}
+}

--- a/pkg/server/api/flowstream_auth_test.go
+++ b/pkg/server/api/flowstream_auth_test.go
@@ -17,9 +17,12 @@ package api
 import (
 	"bufio"
 	"context"
+	"io"
 	"net/http"
 	"net/http/httptest"
 	"strings"
+	"sync"
+	"sync/atomic"
 	"testing"
 	"time"
 
@@ -29,76 +32,238 @@ import (
 	"github.com/stretchr/testify/require"
 
 	apisv1 "antrea.io/antrea-ui/apis/v1"
+	"antrea.io/antrea-ui/pkg/auth/session"
 	"antrea.io/antrea-ui/pkg/handlers/flowstream"
 )
 
 // flowingSubscriber delivers one flow record immediately, so a test can tell whether the caller
-// actually received flow data rather than just a status code.
-type flowingSubscriber struct{}
+// actually received flow data rather than just a status code. It also counts Subscribe calls, so a
+// denied request can assert the stronger property: not merely that the caller got no data, but that
+// the backend never asked the Flow Aggregator for any on their behalf.
+type flowingSubscriber struct {
+	subscribes atomic.Int32
+}
 
 func (s *flowingSubscriber) Subscribe(ctx context.Context, _ *flowstream.FlowStreamFilter) (<-chan apisv1.FlowStreamEvent, <-chan error) {
+	s.subscribes.Add(1)
 	flowsCh := make(chan apisv1.FlowStreamEvent, 1)
 	errCh := make(chan error)
 	flowsCh <- apisv1.FlowStreamEvent{Flows: []apisv1.Flow{{}}}
 	return flowsCh, errCh
 }
 
-// The flow stream is one of only two routes that resolve an identity and then never present the
-// credential to Kubernetes: it reads from the Flow Aggregator over antrea-ui's own connection. So
-// "the API server will reject a bad token" is not true here, and a token that nothing validated is
-// simply believed - which, since flow data has no per-user authorization either, is the whole of
-// the access control on this endpoint.
-func TestFlowStreamRejectsUnvalidatedBearerToken(t *testing.T) {
-	newStreamingServer := func(t *testing.T) *testServer {
-		ts := newTestServer(t)
-		ts.s.flowStreamSSEHandler = flowstream.NewSSEHandler(testr.New(t), &flowingSubscriber{})
-		router := gin.New()
-		ts.s.AddRoutes(&router.RouterGroup)
-		ts.router = router
-		return ts
-	}
+// newStreamingServer builds a Server whose flow stream route is the real one (a nil subscriber
+// registers flowStreamDisabled instead, and with it no requireFlowVisibility middleware), on top
+// of the fake K8s API server so the gate's SelfSubjectAccessReview can be answered.
+func newStreamingServer(t *testing.T) (*testServer, *fakeAccessK8sAPIServer, *flowingSubscriber, <-chan struct{}) {
+	ts, fakeAPIServer := newTestServerForAccess(t, nil)
+	subscriber := &flowingSubscriber{}
+	ts.s.flowStreamSSEHandler = flowstream.NewSSEHandler(testr.New(t), subscriber)
+	router := gin.New()
+	// Closed once the first request's whole handler chain has returned, which is the
+	// happens-before edge a "did not subscribe" assertion needs: the client's Do() returns as
+	// soon as the response headers arrive, so reading the counter at that point could race a
+	// handler still on its way to Subscribe. Registered first, so its c.Next() wraps every later
+	// handler. The channel belongs to the server, not to a request, so a second request through
+	// the same router must not close it again: sync.OnceFunc makes the edge mean "the first
+	// request's chain has returned" instead of panicking on the second.
+	handlerReturned := make(chan struct{})
+	closeOnce := sync.OnceFunc(func() { close(handlerReturned) })
+	router.Use(func(c *gin.Context) {
+		defer closeOnce()
+		c.Next()
+	})
+	ts.s.AddRoutes(&router.RouterGroup)
+	ts.router = router
+	return ts, fakeAPIServer, subscriber, handlerReturned
+}
 
-	// httptest.ResponseRecorder does not implement http.CloseNotifier, which gin's Stream needs,
-	// so the stream cases need a real server.
-	openStream := func(t *testing.T, ts *testServer, token string) (*http.Response, func()) {
-		srv := httptest.NewServer(ts.router)
-		ctx, cancel := context.WithTimeout(t.Context(), 5*time.Second)
-		req, err := http.NewRequestWithContext(ctx, "GET", srv.URL+"/api/v1/flows/stream", nil)
-		require.NoError(t, err)
-		req.Header.Set("Authorization", "Bearer "+token)
-		resp, err := http.DefaultClient.Do(req)
-		require.NoError(t, err)
-		return resp, func() {
-			cancel()
-			resp.Body.Close()
-			srv.Close()
+// httptest.ResponseRecorder does not implement http.CloseNotifier, which gin's Stream needs, so
+// the stream cases need a real server.
+func openStream(t *testing.T, ts *testServer, token string) (*http.Response, func()) {
+	srv := httptest.NewServer(ts.router)
+	ctx, cancel := context.WithTimeout(t.Context(), 5*time.Second)
+	req, err := http.NewRequestWithContext(ctx, "GET", srv.URL+"/api/v1/flows/stream", nil)
+	require.NoError(t, err)
+	req.Header.Set("Authorization", "Bearer "+token)
+	resp, err := http.DefaultClient.Do(req)
+	require.NoError(t, err)
+	return resp, func() {
+		cancel()
+		resp.Body.Close()
+		srv.Close()
+	}
+}
+
+// assertRejectedWithoutSubscribing asserts the backend did not ask the Flow Aggregator for flow
+// data on this caller's behalf. Waits for the handler chain to return first, so the counter is read
+// after every code path that could have subscribed has run — no polling, and no window in which a
+// slow handler makes the assertion pass vacuously.
+//
+// A gate that stopped aborting would keep the response open and stream instead of returning, so the
+// chain never completes and this reports that directly. The wait cannot use testing/synctest: the
+// stream cases need a real server (see openStream), and goroutines blocked on real network I/O are
+// never durably blocked, so a bubble would simply hang.
+func assertRejectedWithoutSubscribing(t *testing.T, handlerReturned <-chan struct{}, subscriber *flowingSubscriber, msg string) {
+	t.Helper()
+	select {
+	case <-handlerReturned:
+	case <-time.After(5 * time.Second):
+		t.Fatalf("%s: the handler never returned, so it is still streaming rather than rejecting", msg)
+	}
+	assert.Zero(t, subscriber.subscribes.Load(), msg)
+}
+
+// receivesFlow reports whether the open stream delivered a flow record, rather than just a status
+// code.
+func receivesFlow(t *testing.T, resp *http.Response) bool {
+	t.Helper()
+	scanner := bufio.NewScanner(resp.Body)
+	deadline := time.Now().Add(2 * time.Second)
+	for time.Now().Before(deadline) && scanner.Scan() {
+		if strings.HasPrefix(scanner.Text(), "data:") {
+			return true
 		}
 	}
+	return false
+}
 
+// The flow stream *handler* never presents the caller's credential to Kubernetes: it reads from
+// the Flow Aggregator over antrea-ui's own connection. So "the API server will reject a bad token"
+// is not true of the handler, and a token that nothing validated would simply be believed. The
+// interim gate does present it (its SelfSubjectAccessReview runs as the caller), which happens to
+// catch a bogus token today — but that is a side effect of a temporary restriction, not the
+// guarantee, and it disappears when the gate does. The check in authn.bearer is what this test
+// pins. Flow data has no per-user authorization either, so the only thing narrowing what a
+// validated caller sees is requireFlowVisibility (see TestFlowStreamRequiresAdmin).
+func TestFlowStreamRejectsUnvalidatedBearerToken(t *testing.T) {
 	t.Run("rejected token gets no data", func(t *testing.T) {
-		ts := newStreamingServer(t)
+		ts, fakeAPIServer, subscriber, handlerReturned := newStreamingServer(t)
+		fakeAPIServer.clusterAdmin = true
 		ts.credentialValidator.rejected["bogus"] = true
 		resp, cleanup := openStream(t, ts, "bogus")
 		defer cleanup()
 		assert.Equal(t, http.StatusUnauthorized, resp.StatusCode)
+		assertRejectedWithoutSubscribing(t, handlerReturned, subscriber, "an unauthenticated request must not reach the Flow Aggregator")
 	})
 
 	t.Run("valid token streams", func(t *testing.T) {
-		ts := newStreamingServer(t)
+		ts, fakeAPIServer, _, _ := newStreamingServer(t)
+		// The token still has to clear requireFlowVisibility, which this test is not about.
+		fakeAPIServer.clusterAdmin = true
+		resp, cleanup := openStream(t, ts, "good")
+		defer cleanup()
+		require.Equal(t, http.StatusOK, resp.StatusCode)
+		assert.True(t, receivesFlow(t, resp), "a validated token should receive flow data")
+	})
+}
+
+// requireFlowVisibility is a temporary restriction: flow data has no per-user authorization, so
+// the endpoint is limited to the built-in admin and to Kubernetes cluster admins
+// (antrea-io/antrea-ui#1387).
+func TestFlowStreamRequiresAdmin(t *testing.T) {
+	t.Run("static admin allowed without a K8s call", func(t *testing.T) {
+		ts, fakeAPIServer, _, _ := newStreamingServer(t)
+		// False, so an allow can only come from the ModeAdmin short-circuit. That matches
+		// reality: the antrea-ui-admin ServiceAccount the static-admin session impersonates
+		// holds no */*/* rule.
+		fakeAPIServer.clusterAdmin = false
+		// And nothing at all is reachable, so a call would fail rather than answer false.
+		fakeAPIServer.statusOverride["selfsubjectaccessreviews"] = http.StatusInternalServerError
+
+		srv := httptest.NewServer(ts.router)
+		defer srv.Close()
+		ctx, cancel := context.WithTimeout(t.Context(), 5*time.Second)
+		defer cancel()
+		req, err := http.NewRequestWithContext(ctx, "GET", srv.URL+"/api/v1/flows/stream", nil)
+		require.NoError(t, err)
+		ts.authorizeRequestAs(req, session.ModeAdmin)
+		resp, err := http.DefaultClient.Do(req)
+		require.NoError(t, err)
+		defer resp.Body.Close()
+		require.Equal(t, http.StatusOK, resp.StatusCode)
+		assert.True(t, receivesFlow(t, resp), "the built-in admin should receive flow data")
+	})
+
+	t.Run("cluster admin token allowed", func(t *testing.T) {
+		ts, fakeAPIServer, _, _ := newStreamingServer(t)
+		fakeAPIServer.clusterAdmin = true
+		resp, cleanup := openStream(t, ts, "good")
+		defer cleanup()
+		require.Equal(t, http.StatusOK, resp.StatusCode)
+		assert.True(t, receivesFlow(t, resp), "a cluster admin should receive flow data")
+	})
+
+	t.Run("ordinary user forbidden", func(t *testing.T) {
+		ts, fakeAPIServer, subscriber, handlerReturned := newStreamingServer(t)
+		fakeAPIServer.clusterAdmin = false
+		resp, cleanup := openStream(t, ts, "good")
+		defer cleanup()
+		require.Equal(t, http.StatusForbidden, resp.StatusCode)
+		// The point of the gate, and what the status code alone does not pin down: HandleError
+		// writes a response without aborting, so only requireFlowVisibility's c.Abort() keeps
+		// StreamFlows — and with it the gRPC subscription — from running anyway. Asserted before
+		// the body is read, which would block against a handler that did start streaming.
+		assertRejectedWithoutSubscribing(t, handlerReturned, subscriber, "a forbidden caller must not reach the Flow Aggregator")
+		body, err := io.ReadAll(resp.Body)
+		require.NoError(t, err)
+		assert.Contains(t, string(body), "restricted to administrators")
+	})
+
+	// The gate has to ask the API server "may *this caller* do everything", so it must present
+	// the caller's own credential. Nothing else in the test suite pins that: the fake API server
+	// answers from a field regardless of who asks, so a gate rewritten to use antrea-ui's own
+	// ServiceAccount would pass every other case here. That rewrite is not hypothetical-only —
+	// it is the shape a well-meaning "avoid a per-request client" refactor takes — and it turns
+	// the gate into a property of the deployment rather than of the caller: everyone is denied
+	// under the default chart (the ServiceAccount holds no */*/* rule), and everyone is allowed
+	// wherever an operator has bound it cluster-admin.
+	t.Run("the review is issued with the caller's own credential", func(t *testing.T) {
+		ts, fakeAPIServer, _, _ := newStreamingServer(t)
+		fakeAPIServer.clusterAdmin = true
+		var reviewAuth atomic.Pointer[string]
+		inner := fakeAPIServer.Config.Handler
+		// Safe to swap: the server has served nothing yet, and openStream below is what starts
+		// the first request.
+		fakeAPIServer.Config.Handler = http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			if strings.Contains(r.URL.Path, "selfsubjectaccessreviews") {
+				h := r.Header.Get("Authorization")
+				reviewAuth.Store(&h)
+			}
+			inner.ServeHTTP(w, r)
+		})
+
 		resp, cleanup := openStream(t, ts, "good")
 		defer cleanup()
 		require.Equal(t, http.StatusOK, resp.StatusCode)
 
-		gotFlow := false
-		scanner := bufio.NewScanner(resp.Body)
-		deadline := time.Now().Add(2 * time.Second)
-		for time.Now().Before(deadline) && scanner.Scan() {
-			if strings.HasPrefix(scanner.Text(), "data:") {
-				gotFlow = true
-				break
-			}
-		}
-		assert.True(t, gotFlow, "a validated token should receive flow data")
+		seen := reviewAuth.Load()
+		require.NotNil(t, seen, "the gate did not issue a SelfSubjectAccessReview at all")
+		assert.Equal(t, "Bearer good", *seen, "the review must carry the caller's token, not antrea-ui's own credential")
+	})
+
+	t.Run("review failure fails closed", func(t *testing.T) {
+		ts, fakeAPIServer, subscriber, handlerReturned := newStreamingServer(t)
+		fakeAPIServer.clusterAdmin = true
+		fakeAPIServer.statusOverride["selfsubjectaccessreviews"] = http.StatusInternalServerError
+		resp, cleanup := openStream(t, ts, "good")
+		defer cleanup()
+		assert.Equal(t, http.StatusInternalServerError, resp.StatusCode)
+		assertRejectedWithoutSubscribing(t, handlerReturned, subscriber, "a review we could not evaluate must not reach the Flow Aggregator")
+	})
+
+	t.Run("disabled path is not gated", func(t *testing.T) {
+		// A nil subscriber registers flowStreamDisabled, deliberately without the gate: every
+		// authenticated user should get the same 501 "not enabled" answer, not a 403 giving
+		// the wrong reason. Whether the integration is on is public in GET /api/v1/settings
+		// anyway.
+		ts, fakeAPIServer := newTestServerForAccess(t, nil)
+		fakeAPIServer.clusterAdmin = false
+		req := httptest.NewRequest("GET", "/api/v1/flows/stream", nil)
+		ts.authorizeRequestAs(req, session.ModeToken)
+		rr := httptest.NewRecorder()
+		ts.router.ServeHTTP(rr, req)
+		assert.Equal(t, http.StatusNotImplemented, rr.Code)
 	})
 }
 

--- a/pkg/server/api/server.go
+++ b/pkg/server/api/server.go
@@ -137,7 +137,7 @@ func (s *Server) AddFlowStreamRoutes(r *gin.RouterGroup) {
 		flows.GET("/stream", s.flowStreamDisabled)
 		return
 	}
-	flows.GET("/stream", s.flowStreamSSEHandler.StreamFlows)
+	flows.GET("/stream", s.requireFlowVisibility(), s.flowStreamSSEHandler.StreamFlows)
 }
 
 // flowStreamDisabled handles GET /api/v1/flows/stream when Flow Aggregator integration is off.

--- a/pkg/server/authn/bearer.go
+++ b/pkg/server/authn/bearer.go
@@ -72,10 +72,12 @@ type bearerCacheEntry struct {
 // the check can happen.
 //
 // It cannot be left to the upstream call to reject a bad token, even though for most routes it
-// would. Two routes resolve an identity and then never present the credential to Kubernetes at
-// all - GET /auth/session, and the flow stream, which reads from the Flow Aggregator over
-// antrea-ui's own connection. On those, "the API server will catch it" is not true, and an
-// unvalidated token is simply believed.
+// would. Two route handlers resolve an identity and then never present the credential to
+// Kubernetes at all - GET /auth/session, and the flow stream, which reads from the Flow Aggregator
+// over antrea-ui's own connection. On those, "the API server will catch it" is not true, and an
+// unvalidated token is simply believed. (The flow stream's interim admin-only gate does present
+// the credential today, so it would incidentally catch a bogus token, but that gate is temporary
+// and the handler behind it is not - see requireFlowVisibility.)
 //
 // Validating here rather than in each handler also removes antrea-ui as an unauthenticated,
 // unthrottled way to test Kubernetes credentials against an API server the caller may not be able


### PR DESCRIPTION
`GET /api/v1/flows/stream` is the one route serving cluster data whose handler
never presents the caller's credential to Kubernetes: the backend reads from the
Flow Aggregator over antrea-ui's own gRPC connection, so any user who can log in
sees every exported flow. (`GET /auth/session` is the other route that never
presents it, but it serves no cluster data.) The Flow Aggregator side of per-user authorization is
not in Antrea v2.7.0, so v0.8.0 ships without it.

Until it lands, this narrows the blast radius: the stream is limited to the
built-in admin and to callers holding a cluster-wide wildcard grant, reusing the
`SelfSubjectAccessReview` the access summary already runs. The frontend mirrors
the rule so it does not render UI that would only get a 403, and a 403 on the
stream is now terminal rather than something the reconnect loop retries.

Entirely UI-side: no new API field, no chart or RBAC change.

### The two commits

**`Prepare the pieces a flow-visibility gate needs`** — the parts that outlive
the restriction, split out so a later revert leaves them behind:

- `selfSubjectClusterAdmin` lifted out of `GetAccessSummary`, so a second caller
  can ask the same question without restating why a literal `*` is the right probe.
- `RequirePermission` takes `allowed`/`loaded` instead of a predicate over the
  access summary, so a gate needing more than the summary reuses one wrapper
  instead of duplicating the component to get the same panel.
- `FlowStreamClient` gains `onForbidden`, so a 403 stops the stream the way 501
  already does rather than driving exponential backoff against an answer that
  will not change.

**`Restrict flow visibility to admins`** — the restriction itself, meant to be
reverted in one piece.

### The gate

The built-in admin short-circuits before any Kubernetes call. That is not just an
optimization: the static-admin session impersonates the `antrea-ui-admin`
ServiceAccount, whose aggregated ClusterRole holds no `*/*/*` rule, so the
wildcard review genuinely answers false for it — and keeping the check off the
API server means a broken API server cannot lock out the one session an operator
uses to fix a cluster. Same reasoning as step 4 of `GetAccessSummary`.

Everything else fails closed: a review that could not be evaluated is not an
allow. The frontend's `useCanViewFlows` is not a second gate — the middleware is
the authorization decision and aborts on every path that is not an allow, so the
backend never subscribes to the Flow Aggregator for a caller it rejected. The
hook only decides what to render, and therefore fails *open* on an access
summary that never arrived, like the `can()` gates: denying there would strand a
cluster admin behind the generic permission panel for the rest of the page
lifetime after one transient failure, whereas allowing defers to the 403, which
`onForbidden` renders as a terminal panel naming the actual restriction. The
same applies to a missing session probe, which leaves the built-in admin's mode
unknown while their summary correctly reports `clusterAdmin: false` — denying
there would hide the page from exactly the caller the middleware short-circuits
to an allow. Only a definite answer on both — a real session that is not the
built-in admin, and `clusterAdmin: false` — hides the page.

The disabled path (`flowAggregator.enabled=false`) is deliberately left ungated,
so every authenticated user gets the same 501 "not enabled" answer rather than a
403 giving the wrong reason. Whether the integration is on is already public in
`GET /api/v1/settings`.

Two smaller changes fall out of gating Flow Visibility: it is no longer the floor
for the initial redirect (a user permitted none of the three lands on Settings,
which needs no permission), and a nav group hidden by a gate no longer promotes
its own built-in sub-pages to top level, which would render links to pages the
user cannot open. Nested *plugin* entries are still promoted, as they are for a
gated-off Summary or Traceflow.

### What this does not do

It narrows who is exposed; it does not make flow data per-user. Within the
allowed set, every caller still sees every flow. And the restriction is Antrea
UI's alone: enabling `FlowStreamService` in the Flow Aggregator means anyone with
network access to it can read flow data directly, whatever Antrea UI allows.

`docs/authentication.md` is updated to say all of this. When the upstream fix
lands, that section wants a rewrite rather than a revert: the text this PR
replaced described flow data as reachable by anyone who can log in, which will be
just as false then as the paragraph standing here now.

For #1387. Upstream: antrea-io/antrea#8221.

