### PR TITLE
Localize plugin federation route sidebar labels

### DIFF
--- a/apis/v1/plugins.go
+++ b/apis/v1/plugins.go
@@ -59,11 +59,22 @@ const (
 	PluginRouteKindRoutes    = "routes"
 )
 
+// PluginSidebarLabel maps a BCP 47 language tag (e.g. "en", "en-US", "zh-Hans") to the sidebar
+// label text for that locale. Every manifest must carry at least "en" as a default a
+// locale-unaware or unsupported-locale host can always fall back to; a host with no i18n
+// mechanism at all (e.g. this repo's own frontend, or cayman_antrea-ui's Angular shell today)
+// simply always reads "en".
+type PluginSidebarLabel map[string]string
+
+// DefaultLocale is the locale key every PluginSidebarLabel must carry, for a host with no i18n
+// mechanism, or no entry for its active locale, to fall back to.
+const DefaultLocale = "en"
+
 // PluginRoute mirrors registerRoute()/registerSidebarEntry()'s
 // antrea-ui-plugin-sdk info, as data, plus which component to mount.
 type PluginRoute struct {
-	Path         string `json:"path"`
-	SidebarLabel string `json:"sidebarLabel"`
+	Path         string             `json:"path"`
+	SidebarLabel PluginSidebarLabel `json:"sidebarLabel"`
 	// Icon is optional SVG path "d" data, 16x16 viewBox "0 0 16 16", matching
 	// PluginSidebarEntry.icon in antrea-ui-plugin-sdk.
 	Icon string `json:"icon,omitempty"`

--- a/docs/plugins.md
+++ b/docs/plugins.md
@@ -174,7 +174,7 @@ lives inside `bundle.zip`:
 | `name` | yes | Unique name; also the path segment used to serve the plugin, e.g. `/api/v1/plugins/<name>/`. |
 | `version` | yes | Informational only. |
 | `entry` | yes | Plugin's JS module filename; must be an entry in the same plugin's `bundle.zip`. Always eagerly `import()`-ed by the host at startup, for whatever page-extension registration the plugin's code performs (see below) — independent of `federation`. Required even for a plugin whose only page(s) are a `federation` remote with no other page-extension registration; such a plugin still needs a real ES module here, distinct from `federation.remoteEntry` — see below. |
-| `federation` | no | `{remoteEntry, routes: [{path, sidebarLabel, icon?, exposedModule, kind?}]}` — a [Native Federation](https://www.npmjs.com/package/@angular-architects/native-federation) remote (its own entry in `bundle.zip`, separate from `entry`) plus the whole-page routes/sidebar entries it serves, as data instead of registering them in code (see below). Antrea UI's own frontend has no module federation loader and ignores this field entirely (see `plugins.ts`); it's consumed by a separate, out-of-tree Angular-based host, which lazily loads a route's `exposedModule` out of `remoteEntry`, only once that route is actually visited. `kind` is `"component"` (the default) or `"routes"` — any other value is rejected, dropping the whole plugin (see below): `"component"` expects `exposedModule` to export a single page component; `"routes"` expects it to export a whole route tree the plugin owns end to end, letting it nest its own sub-paths and register its own route-level providers without the host knowing anything about them. Since a `"routes"` route owns every sub-path under its own `path`, no other route in the same manifest may fall under it (rejected the same way two routes with an identical `path` are); a route nested under it in a *different*, already-installed plugin's manifest is resolved the same way an identical `path` across plugins is (see below). |
+| `federation` | no | `{remoteEntry, routes: [{path, sidebarLabel: {<locale>: <label>, ...}, icon?, exposedModule, kind?}]}` — a [Native Federation](https://www.npmjs.com/package/@angular-architects/native-federation) remote (its own entry in `bundle.zip`, separate from `entry`) plus the whole-page routes/sidebar entries it serves, as data instead of registering them in code (see below). Antrea UI's own frontend has no module federation loader and ignores this field entirely (see `plugins.ts`); it's consumed by a separate, out-of-tree Angular-based host, which lazily loads a route's `exposedModule` out of `remoteEntry`, only once that route is actually visited. `sidebarLabel` maps a BCP 47 locale tag (e.g. `en`, `en-US`, `zh-Hans`) to that locale's label text, and must always carry an `"en"` entry: a host with no i18n mechanism of its own (e.g. this repo's own frontend, or `cayman_antrea-ui`'s Angular shell today) always reads `sidebarLabel["en"]`; a host with real i18n picks whichever locale key matches its active locale, falling back to `"en"` if the map has no entry for it. `kind` is `"component"` (the default) or `"routes"` — any other value is rejected, dropping the whole plugin (see below): `"component"` expects `exposedModule` to export a single page component; `"routes"` expects it to export a whole route tree the plugin owns end to end, letting it nest its own sub-paths and register its own route-level providers without the host knowing anything about them. Since a `"routes"` route owns every sub-path under its own `path`, no other route in the same manifest may fall under it (rejected the same way two routes with an identical `path` are); a route nested under it in a *different*, already-installed plugin's manifest is resolved the same way an identical `path` across plugins is (see below). |
 
 `bundle.zip`'s own internal layout is entirely up to the plugin — a flat set
 of files, or nested paths like `assets/logo.png` for anything referenced by
@@ -205,7 +205,7 @@ A manifest declaring `federation`:
     "routes": [
       {
         "path": "/policies",
-        "sidebarLabel": "Policy Management",
+        "sidebarLabel": {"en": "Policy Management"},
         "icon": "M0 0h16v16H0z",
         "exposedModule": "./PolicyManagementPage"
       }
@@ -229,7 +229,9 @@ it:
   remote entry is not.
 - `federation.routes` must be non-empty — a remote with nothing to mount is
   meaningless on its own.
-- Each route needs `path`, `sidebarLabel`, and `exposedModule`.
+- Each route needs `path`, `sidebarLabel`, and `exposedModule`. `sidebarLabel` is a locale-keyed
+  map and must include an `"en"` entry; an empty value for any locale key it does carry is also
+  rejected (omit the key entirely for a locale with no translation, rather than a blank string).
 - `path` may not be the root path (`/`) or fall under a path nginx proxies
   straight to the backend (currently `api`, `auth`, e.g. `/api/v1/foo` or
   `/authors`) — the former collides with the host's own home page, the

--- a/pkg/plugins/configmaps_test.go
+++ b/pkg/plugins/configmaps_test.go
@@ -173,7 +173,7 @@ func TestRegistrySkipsInvalidConfigMaps(t *testing.T) {
 		},
 		"route missing path": func(t *testing.T) *corev1.ConfigMap {
 			return withBundle(t,
-				`{"name":"plugin","version":"0.1.0","entry":"index.js","federation":{"remoteEntry":"remoteEntry.json","routes":[{"sidebarLabel":"Plugin","exposedModule":"./Page"}]}}`,
+				`{"name":"plugin","version":"0.1.0","entry":"index.js","federation":{"remoteEntry":"remoteEntry.json","routes":[{"sidebarLabel":{"en":"Plugin"},"exposedModule":"./Page"}]}}`,
 				map[string]string{"index.js": "x", "remoteEntry.json": "x"})
 		},
 		"route missing sidebarLabel": func(t *testing.T) *corev1.ConfigMap {
@@ -181,21 +181,31 @@ func TestRegistrySkipsInvalidConfigMaps(t *testing.T) {
 				`{"name":"plugin","version":"0.1.0","entry":"index.js","federation":{"remoteEntry":"remoteEntry.json","routes":[{"path":"/plugin","exposedModule":"./Page"}]}}`,
 				map[string]string{"index.js": "x", "remoteEntry.json": "x"})
 		},
+		"route sidebarLabel missing the en locale": func(t *testing.T) *corev1.ConfigMap {
+			return withBundle(t,
+				`{"name":"plugin","version":"0.1.0","entry":"index.js","federation":{"remoteEntry":"remoteEntry.json","routes":[{"path":"/plugin","sidebarLabel":{"fr":"Plugin"},"exposedModule":"./Page"}]}}`,
+				map[string]string{"index.js": "x", "remoteEntry.json": "x"})
+		},
+		"route sidebarLabel has a blank value for a locale": func(t *testing.T) *corev1.ConfigMap {
+			return withBundle(t,
+				`{"name":"plugin","version":"0.1.0","entry":"index.js","federation":{"remoteEntry":"remoteEntry.json","routes":[{"path":"/plugin","sidebarLabel":{"en":"Plugin","fr":""},"exposedModule":"./Page"}]}}`,
+				map[string]string{"index.js": "x", "remoteEntry.json": "x"})
+		},
 		"route missing exposedModule": func(t *testing.T) *corev1.ConfigMap {
 			return withBundle(t,
-				`{"name":"plugin","version":"0.1.0","entry":"index.js","federation":{"remoteEntry":"remoteEntry.json","routes":[{"path":"/plugin","sidebarLabel":"Plugin"}]}}`,
+				`{"name":"plugin","version":"0.1.0","entry":"index.js","federation":{"remoteEntry":"remoteEntry.json","routes":[{"path":"/plugin","sidebarLabel":{"en":"Plugin"}}]}}`,
 				map[string]string{"index.js": "x", "remoteEntry.json": "x"})
 		},
 		"route with an unknown kind": func(t *testing.T) *corev1.ConfigMap {
 			return withBundle(t,
-				`{"name":"plugin","version":"0.1.0","entry":"index.js","federation":{"remoteEntry":"remoteEntry.json","routes":[{"path":"/plugin","sidebarLabel":"Plugin","exposedModule":"./Page","kind":"route"}]}}`,
+				`{"name":"plugin","version":"0.1.0","entry":"index.js","federation":{"remoteEntry":"remoteEntry.json","routes":[{"path":"/plugin","sidebarLabel":{"en":"Plugin"},"exposedModule":"./Page","kind":"route"}]}}`,
 				map[string]string{"index.js": "x", "remoteEntry.json": "x"})
 		},
 		"route nested under a routes-kind route": func(t *testing.T) *corev1.ConfigMap {
 			return withBundle(t,
 				`{"name":"plugin","version":"0.1.0","entry":"index.js","federation":{"remoteEntry":"remoteEntry.json","routes":[
-					{"path":"/policies","sidebarLabel":"Policies","exposedModule":"./PolicyRoutes","kind":"routes"},
-					{"path":"/policies/audit","sidebarLabel":"Audit","exposedModule":"./PolicyAuditPage"}
+					{"path":"/policies","sidebarLabel":{"en":"Policies"},"exposedModule":"./PolicyRoutes","kind":"routes"},
+					{"path":"/policies/audit","sidebarLabel":{"en":"Audit"},"exposedModule":"./PolicyAuditPage"}
 				]}}`,
 				map[string]string{"index.js": "x", "remoteEntry.json": "x"})
 		},
@@ -204,52 +214,52 @@ func TestRegistrySkipsInvalidConfigMaps(t *testing.T) {
 		"routes-kind route declared after the route it owns": func(t *testing.T) *corev1.ConfigMap {
 			return withBundle(t,
 				`{"name":"plugin","version":"0.1.0","entry":"index.js","federation":{"remoteEntry":"remoteEntry.json","routes":[
-					{"path":"policies/audit","sidebarLabel":"Audit","exposedModule":"./PolicyAuditPage"},
-					{"path":"/policies/","sidebarLabel":"Policies","exposedModule":"./PolicyRoutes","kind":"routes"}
+					{"path":"policies/audit","sidebarLabel":{"en":"Audit"},"exposedModule":"./PolicyAuditPage"},
+					{"path":"/policies/","sidebarLabel":{"en":"Policies"},"exposedModule":"./PolicyRoutes","kind":"routes"}
 				]}}`,
 				map[string]string{"index.js": "x", "remoteEntry.json": "x"})
 		},
 		"route path under reserved api prefix": func(t *testing.T) *corev1.ConfigMap {
 			return withBundle(t,
-				`{"name":"plugin","version":"0.1.0","entry":"index.js","federation":{"remoteEntry":"remoteEntry.json","routes":[{"path":"/apiobjects","sidebarLabel":"Plugin","exposedModule":"./Page"}]}}`,
+				`{"name":"plugin","version":"0.1.0","entry":"index.js","federation":{"remoteEntry":"remoteEntry.json","routes":[{"path":"/apiobjects","sidebarLabel":{"en":"Plugin"},"exposedModule":"./Page"}]}}`,
 				map[string]string{"index.js": "x", "remoteEntry.json": "x"})
 		},
 		"route path under reserved auth prefix": func(t *testing.T) *corev1.ConfigMap {
 			return withBundle(t,
-				`{"name":"plugin","version":"0.1.0","entry":"index.js","federation":{"remoteEntry":"remoteEntry.json","routes":[{"path":"/authors","sidebarLabel":"Plugin","exposedModule":"./Page"}]}}`,
+				`{"name":"plugin","version":"0.1.0","entry":"index.js","federation":{"remoteEntry":"remoteEntry.json","routes":[{"path":"/authors","sidebarLabel":{"en":"Plugin"},"exposedModule":"./Page"}]}}`,
 				map[string]string{"index.js": "x", "remoteEntry.json": "x"})
 		},
 		"route path is the root path": func(t *testing.T) *corev1.ConfigMap {
 			return withBundle(t,
-				`{"name":"plugin","version":"0.1.0","entry":"index.js","federation":{"remoteEntry":"remoteEntry.json","routes":[{"path":"/","sidebarLabel":"Plugin","exposedModule":"./Page"}]}}`,
+				`{"name":"plugin","version":"0.1.0","entry":"index.js","federation":{"remoteEntry":"remoteEntry.json","routes":[{"path":"/","sidebarLabel":{"en":"Plugin"},"exposedModule":"./Page"}]}}`,
 				map[string]string{"index.js": "x", "remoteEntry.json": "x"})
 		},
 		"route path collapses to the root path via dot segments": func(t *testing.T) *corev1.ConfigMap {
 			return withBundle(t,
-				`{"name":"plugin","version":"0.1.0","entry":"index.js","federation":{"remoteEntry":"remoteEntry.json","routes":[{"path":"/plugin/..","sidebarLabel":"Plugin","exposedModule":"./Page"}]}}`,
+				`{"name":"plugin","version":"0.1.0","entry":"index.js","federation":{"remoteEntry":"remoteEntry.json","routes":[{"path":"/plugin/..","sidebarLabel":{"en":"Plugin"},"exposedModule":"./Page"}]}}`,
 				map[string]string{"index.js": "x", "remoteEntry.json": "x"})
 		},
 		"duplicate route path in the same manifest": func(t *testing.T) *corev1.ConfigMap {
 			return withBundle(t,
 				`{"name":"plugin","version":"0.1.0","entry":"index.js","federation":{"remoteEntry":"remoteEntry.json","routes":[
-					{"path":"/plugin","sidebarLabel":"Plugin","exposedModule":"./Page"},
-					{"path":"/plugin","sidebarLabel":"Plugin Again","exposedModule":"./OtherPage"}
+					{"path":"/plugin","sidebarLabel":{"en":"Plugin"},"exposedModule":"./Page"},
+					{"path":"/plugin","sidebarLabel":{"en":"Plugin Again"},"exposedModule":"./OtherPage"}
 				]}}`,
 				map[string]string{"index.js": "x", "remoteEntry.json": "x"})
 		},
 		"duplicate route path differing only by leading slash": func(t *testing.T) *corev1.ConfigMap {
 			return withBundle(t,
 				`{"name":"plugin","version":"0.1.0","entry":"index.js","federation":{"remoteEntry":"remoteEntry.json","routes":[
-					{"path":"/plugin","sidebarLabel":"Plugin","exposedModule":"./Page"},
-					{"path":"plugin","sidebarLabel":"Plugin Again","exposedModule":"./OtherPage"}
+					{"path":"/plugin","sidebarLabel":{"en":"Plugin"},"exposedModule":"./Page"},
+					{"path":"plugin","sidebarLabel":{"en":"Plugin Again"},"exposedModule":"./OtherPage"}
 				]}}`,
 				map[string]string{"index.js": "x", "remoteEntry.json": "x"})
 		},
 		"duplicate route path differing only by doubled and trailing slashes": func(t *testing.T) *corev1.ConfigMap {
 			return withBundle(t,
 				`{"name":"plugin","version":"0.1.0","entry":"index.js","federation":{"remoteEntry":"remoteEntry.json","routes":[
-					{"path":"/plugin","sidebarLabel":"Plugin","exposedModule":"./Page"},
-					{"path":"//plugin/","sidebarLabel":"Plugin Again","exposedModule":"./OtherPage"}
+					{"path":"/plugin","sidebarLabel":{"en":"Plugin"},"exposedModule":"./Page"},
+					{"path":"//plugin/","sidebarLabel":{"en":"Plugin Again"},"exposedModule":"./OtherPage"}
 				]}}`,
 				map[string]string{"index.js": "x", "remoteEntry.json": "x"})
 		},
@@ -263,12 +273,12 @@ func TestRegistrySkipsInvalidConfigMaps(t *testing.T) {
 		},
 		"federation remoteEntry same file as entry": func(t *testing.T) *corev1.ConfigMap {
 			return withBundle(t,
-				`{"name":"plugin","version":"0.1.0","entry":"shared.js","federation":{"remoteEntry":"shared.js","routes":[{"path":"/plugin","sidebarLabel":"Plugin","exposedModule":"./Page"}]}}`,
+				`{"name":"plugin","version":"0.1.0","entry":"shared.js","federation":{"remoteEntry":"shared.js","routes":[{"path":"/plugin","sidebarLabel":{"en":"Plugin"},"exposedModule":"./Page"}]}}`,
 				map[string]string{"shared.js": "x"})
 		},
 		"federation remoteEntry same file as entry, differing only by a non-clean prefix": func(t *testing.T) *corev1.ConfigMap {
 			return withBundle(t,
-				`{"name":"plugin","version":"0.1.0","entry":"shared.js","federation":{"remoteEntry":"./shared.js","routes":[{"path":"/plugin","sidebarLabel":"Plugin","exposedModule":"./Page"}]}}`,
+				`{"name":"plugin","version":"0.1.0","entry":"shared.js","federation":{"remoteEntry":"./shared.js","routes":[{"path":"/plugin","sidebarLabel":{"en":"Plugin"},"exposedModule":"./Page"}]}}`,
 				map[string]string{"shared.js": "x"})
 		},
 		"federation remoteEntry file not present": func(t *testing.T) *corev1.ConfigMap {

--- a/pkg/plugins/disk_test.go
+++ b/pkg/plugins/disk_test.go
@@ -94,8 +94,8 @@ func TestParsePluginArchiveIncludesRoutesAndFederation(t *testing.T) {
 			"federation": {
 				"remoteEntry": "remoteEntry.json",
 				"routes": [
-					{"path": "/policies", "sidebarLabel": "Policy Management", "icon": "M0 0h16v16H0z", "exposedModule": "./PolicyManagementPage"},
-					{"path": "/policies/audit", "sidebarLabel": "Policy Audit Log", "exposedModule": "./PolicyAuditPage"}
+					{"path": "/policies", "sidebarLabel":{"en":"Policy Management"}, "icon": "M0 0h16v16H0z", "exposedModule": "./PolicyManagementPage"},
+					{"path": "/policies/audit", "sidebarLabel":{"en":"Policy Audit Log"}, "exposedModule": "./PolicyAuditPage"}
 				]
 			}
 		}`, map[string]string{
@@ -112,8 +112,8 @@ func TestParsePluginArchiveIncludesRoutesAndFederation(t *testing.T) {
 		Federation: &apisv1.PluginFederation{
 			RemoteEntry: "remoteEntry.json",
 			Routes: []apisv1.PluginRoute{
-				{Path: "/policies", SidebarLabel: "Policy Management", Icon: "M0 0h16v16H0z", ExposedModule: "./PolicyManagementPage"},
-				{Path: "/policies/audit", SidebarLabel: "Policy Audit Log", ExposedModule: "./PolicyAuditPage"},
+				{Path: "/policies", SidebarLabel: apisv1.PluginSidebarLabel{"en": "Policy Management"}, Icon: "M0 0h16v16H0z", ExposedModule: "./PolicyManagementPage"},
+				{Path: "/policies/audit", SidebarLabel: apisv1.PluginSidebarLabel{"en": "Policy Audit Log"}, ExposedModule: "./PolicyAuditPage"},
 			},
 		},
 	}, entry.manifest)
@@ -125,11 +125,11 @@ func TestParsePluginArchiveRejectsInvalidFederationRoutes(t *testing.T) {
 		bundle   map[string]string
 	}{
 		"route missing path": {
-			`{"name":"plugin","version":"0.1.0","entry":"index.js","federation":{"remoteEntry":"remoteEntry.json","routes":[{"sidebarLabel":"Plugin","exposedModule":"./Page"}]}}`,
+			`{"name":"plugin","version":"0.1.0","entry":"index.js","federation":{"remoteEntry":"remoteEntry.json","routes":[{"sidebarLabel":{"en":"Plugin"},"exposedModule":"./Page"}]}}`,
 			map[string]string{"index.js": "x", "remoteEntry.json": "x"},
 		},
 		"route path under reserved api/ prefix": {
-			`{"name":"plugin","version":"0.1.0","entry":"index.js","federation":{"remoteEntry":"remoteEntry.json","routes":[{"path":"/api/v1/plugin","sidebarLabel":"Plugin","exposedModule":"./Page"}]}}`,
+			`{"name":"plugin","version":"0.1.0","entry":"index.js","federation":{"remoteEntry":"remoteEntry.json","routes":[{"path":"/api/v1/plugin","sidebarLabel":{"en":"Plugin"},"exposedModule":"./Page"}]}}`,
 			map[string]string{"index.js": "x", "remoteEntry.json": "x"},
 		},
 		"federation remoteEntry file not present": {

--- a/pkg/plugins/manifest.go
+++ b/pkg/plugins/manifest.go
@@ -126,8 +126,16 @@ func validateManifest(manifestJSON []byte, names map[string]bool) (*apisv1.Plugi
 			if route.Path == "" {
 				return nil, fmt.Errorf("manifest's 'federation.routes[%d]' is missing 'path'", i)
 			}
-			if route.SidebarLabel == "" {
+			if len(route.SidebarLabel) == 0 {
 				return nil, fmt.Errorf("manifest's 'federation.routes[%d]' is missing 'sidebarLabel'", i)
+			}
+			if route.SidebarLabel[apisv1.DefaultLocale] == "" {
+				return nil, fmt.Errorf("manifest's 'federation.routes[%d].sidebarLabel' is missing a %q entry", i, apisv1.DefaultLocale)
+			}
+			for locale, label := range route.SidebarLabel {
+				if label == "" {
+					return nil, fmt.Errorf("manifest's 'federation.routes[%d].sidebarLabel' has an empty value for locale %q", i, locale)
+				}
 			}
 			if route.ExposedModule == "" {
 				return nil, fmt.Errorf("manifest's 'federation.routes[%d]' is missing 'exposedModule'", i)

--- a/pkg/plugins/registry_test.go
+++ b/pkg/plugins/registry_test.go
@@ -40,9 +40,9 @@ func TestRegistryIndexIncludesFederation(t *testing.T) {
 				"federation": {
 					"remoteEntry": "remoteEntry.json",
 					"routes": [
-						{"path": "/policies", "sidebarLabel": "Policy Management", "icon": "M0 0h16v16H0z", "exposedModule": "./PolicyRoutes", "kind": "routes"},
-						{"path": "/policy-audit", "sidebarLabel": "Policy Audit Log", "exposedModule": "./PolicyAuditPage"},
-						{"path": "/policy-summary", "sidebarLabel": "Policy Summary", "exposedModule": "./PolicySummaryPage", "kind": "component"}
+						{"path": "/policies", "sidebarLabel":{"en":"Policy Management"}, "icon": "M0 0h16v16H0z", "exposedModule": "./PolicyRoutes", "kind": "routes"},
+						{"path": "/policy-audit", "sidebarLabel":{"en":"Policy Audit Log"}, "exposedModule": "./PolicyAuditPage"},
+						{"path": "/policy-summary", "sidebarLabel":{"en":"Policy Summary"}, "exposedModule": "./PolicySummaryPage", "kind": "component"}
 					]
 				}
 			}`,
@@ -59,9 +59,9 @@ func TestRegistryIndexIncludesFederation(t *testing.T) {
 		Federation: &apisv1.PluginFederation{
 			RemoteEntry: "remoteEntry.json",
 			Routes: []apisv1.PluginRoute{
-				{Path: "/policies", SidebarLabel: "Policy Management", Icon: "M0 0h16v16H0z", ExposedModule: "./PolicyRoutes", Kind: "routes"},
-				{Path: "/policy-audit", SidebarLabel: "Policy Audit Log", ExposedModule: "./PolicyAuditPage"},
-				{Path: "/policy-summary", SidebarLabel: "Policy Summary", ExposedModule: "./PolicySummaryPage", Kind: "component"},
+				{Path: "/policies", SidebarLabel: apisv1.PluginSidebarLabel{"en": "Policy Management"}, Icon: "M0 0h16v16H0z", ExposedModule: "./PolicyRoutes", Kind: "routes"},
+				{Path: "/policy-audit", SidebarLabel: apisv1.PluginSidebarLabel{"en": "Policy Audit Log"}, ExposedModule: "./PolicyAuditPage"},
+				{Path: "/policy-summary", SidebarLabel: apisv1.PluginSidebarLabel{"en": "Policy Summary"}, ExposedModule: "./PolicySummaryPage", Kind: "component"},
 			},
 		},
 	}}, r.Index())
@@ -96,9 +96,9 @@ func TestRegistryIndexDropsPluginWhenAllFederationRoutesCollide(t *testing.T) {
 	r := newTestRegistry(t)
 
 	r.handleUpsert(federationConfigMap(t, "b-configmap", "b-plugin", "index.js",
-		`[{"path": "//policies/", "sidebarLabel": "Policies", "exposedModule": "./Page"}]`))
+		`[{"path": "//policies/", "sidebarLabel":{"en":"Policies"}, "exposedModule": "./Page"}]`))
 	r.handleUpsert(federationConfigMap(t, "a-configmap", "a-plugin", "index.js",
-		`[{"path": "/policies", "sidebarLabel": "Policies", "exposedModule": "./Page"}]`))
+		`[{"path": "/policies", "sidebarLabel":{"en":"Policies"}, "exposedModule": "./Page"}]`))
 
 	manifests := r.Index()
 	require.Len(t, manifests, 1)
@@ -113,11 +113,11 @@ func TestRegistryIndexFiltersCollidingFederationRouteKeepsRestOfPlugin(t *testin
 	r := newTestRegistry(t)
 
 	r.handleUpsert(federationConfigMap(t, "a-configmap", "a-plugin", "a.js",
-		`[{"path": "/policies", "sidebarLabel": "Policies", "exposedModule": "./Page"}]`))
+		`[{"path": "/policies", "sidebarLabel":{"en":"Policies"}, "exposedModule": "./Page"}]`))
 	r.handleUpsert(federationConfigMap(t, "b-configmap", "b-plugin", "b.js",
 		`[
-			{"path": "/policies", "sidebarLabel": "Policies Again", "exposedModule": "./OtherPage"},
-			{"path": "/other", "sidebarLabel": "Other", "exposedModule": "./OtherPage"}
+			{"path": "/policies", "sidebarLabel":{"en":"Policies Again"}, "exposedModule": "./OtherPage"},
+			{"path": "/other", "sidebarLabel":{"en":"Other"}, "exposedModule": "./OtherPage"}
 		]`))
 
 	manifests := r.Index()
@@ -126,7 +126,7 @@ func TestRegistryIndexFiltersCollidingFederationRouteKeepsRestOfPlugin(t *testin
 	assert.Equal(t, "b-plugin", manifests[1].Name)
 	require.NotNil(t, manifests[1].Federation)
 	assert.Equal(t, []apisv1.PluginRoute{
-		{Path: "/other", SidebarLabel: "Other", ExposedModule: "./OtherPage"},
+		{Path: "/other", SidebarLabel: apisv1.PluginSidebarLabel{"en": "Other"}, ExposedModule: "./OtherPage"},
 	}, manifests[1].Federation.Routes)
 }
 
@@ -141,11 +141,11 @@ func TestRegistryIndexFiltersFederationRouteUnderEarlierPluginsRouteTree(t *test
 	r := newTestRegistry(t)
 
 	r.handleUpsert(federationConfigMap(t, "a-configmap", "a-plugin", "a.js",
-		`[{"path": "/policies", "sidebarLabel": "Policies", "exposedModule": "./Page", "kind": "routes"}]`))
+		`[{"path": "/policies", "sidebarLabel":{"en":"Policies"}, "exposedModule": "./Page", "kind": "routes"}]`))
 	r.handleUpsert(federationConfigMap(t, "b-configmap", "b-plugin", "b.js",
 		`[
-			{"path": "/policies/audit", "sidebarLabel": "Policy Audit", "exposedModule": "./AuditPage"},
-			{"path": "/other", "sidebarLabel": "Other", "exposedModule": "./OtherPage"}
+			{"path": "/policies/audit", "sidebarLabel":{"en":"Policy Audit"}, "exposedModule": "./AuditPage"},
+			{"path": "/other", "sidebarLabel":{"en":"Other"}, "exposedModule": "./OtherPage"}
 		]`))
 
 	manifests := r.Index()
@@ -154,7 +154,7 @@ func TestRegistryIndexFiltersFederationRouteUnderEarlierPluginsRouteTree(t *test
 	assert.Equal(t, "b-plugin", manifests[1].Name)
 	require.NotNil(t, manifests[1].Federation)
 	assert.Equal(t, []apisv1.PluginRoute{
-		{Path: "/other", SidebarLabel: "Other", ExposedModule: "./OtherPage"},
+		{Path: "/other", SidebarLabel: apisv1.PluginSidebarLabel{"en": "Other"}, ExposedModule: "./OtherPage"},
 	}, manifests[1].Federation.Routes)
 }
 
@@ -170,11 +170,11 @@ func TestRegistryIndexFiltersRouteTreeRouteThatWouldClaimAnAlreadyClaimedPath(t 
 	r := newTestRegistry(t)
 
 	r.handleUpsert(federationConfigMap(t, "a-configmap", "a-plugin", "a.js",
-		`[{"path": "/policies/audit", "sidebarLabel": "Policy Audit", "exposedModule": "./AuditPage"}]`))
+		`[{"path": "/policies/audit", "sidebarLabel":{"en":"Policy Audit"}, "exposedModule": "./AuditPage"}]`))
 	r.handleUpsert(federationConfigMap(t, "b-configmap", "b-plugin", "b.js",
 		`[
-			{"path": "/policies", "sidebarLabel": "Policies", "exposedModule": "./Page", "kind": "routes"},
-			{"path": "/other", "sidebarLabel": "Other", "exposedModule": "./OtherPage"}
+			{"path": "/policies", "sidebarLabel":{"en":"Policies"}, "exposedModule": "./Page", "kind": "routes"},
+			{"path": "/other", "sidebarLabel":{"en":"Other"}, "exposedModule": "./OtherPage"}
 		]`))
 
 	manifests := r.Index()
@@ -182,13 +182,13 @@ func TestRegistryIndexFiltersRouteTreeRouteThatWouldClaimAnAlreadyClaimedPath(t 
 	assert.Equal(t, "a-plugin", manifests[0].Name)
 	require.NotNil(t, manifests[0].Federation)
 	assert.Equal(t, []apisv1.PluginRoute{
-		{Path: "/policies/audit", SidebarLabel: "Policy Audit", ExposedModule: "./AuditPage"},
+		{Path: "/policies/audit", SidebarLabel: apisv1.PluginSidebarLabel{"en": "Policy Audit"}, ExposedModule: "./AuditPage"},
 	}, manifests[0].Federation.Routes)
 
 	assert.Equal(t, "b-plugin", manifests[1].Name)
 	require.NotNil(t, manifests[1].Federation)
 	assert.Equal(t, []apisv1.PluginRoute{
-		{Path: "/other", SidebarLabel: "Other", ExposedModule: "./OtherPage"},
+		{Path: "/other", SidebarLabel: apisv1.PluginSidebarLabel{"en": "Other"}, ExposedModule: "./OtherPage"},
 	}, manifests[1].Federation.Routes)
 }
 
@@ -202,13 +202,13 @@ func TestRegistryIndexAndFileStayConsistentWhenAllRoutesCollide(t *testing.T) {
 	r := newTestRegistry(t)
 
 	r.handleUpsert(federationConfigMap(t, "a-configmap", "aaa", "a.js",
-		`[{"path": "/policies", "sidebarLabel": "Policies", "exposedModule": "./Page"}]`))
+		`[{"path": "/policies", "sidebarLabel":{"en":"Policies"}, "exposedModule": "./Page"}]`))
 	// b-configmap sorts before c-configmap, and claims the "dup" name first;
 	// its one route collides with aaa's, so the whole manifest is dropped.
 	r.handleUpsert(federationConfigMap(t, "b-configmap", "dup", "b.js",
-		`[{"path": "/policies", "sidebarLabel": "Policies", "exposedModule": "./Page"}]`))
+		`[{"path": "/policies", "sidebarLabel":{"en":"Policies"}, "exposedModule": "./Page"}]`))
 	r.handleUpsert(federationConfigMap(t, "c-configmap", "dup", "c.js",
-		`[{"path": "/other", "sidebarLabel": "Other", "exposedModule": "./Page"}]`))
+		`[{"path": "/other", "sidebarLabel":{"en":"Other"}, "exposedModule": "./Page"}]`))
 
 	manifests := r.Index()
 	names := make([]string, len(manifests))


### PR DESCRIPTION
PluginRoute.SidebarLabel is now a locale-keyed map (BCP 47 tag -> label text) instead of a single hardcoded string, so a plugin manifest can ship translations for its federation-route sidebar entries. Every manifest must carry an "en" entry as the default a locale-unaware or unsupported-locale host falls back to; any locale key present must not map to an empty string.